### PR TITLE
Add desktop scan bridge

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
+    "@zpace/scanner": "workspace:*",
     "electrobun": "^1.15.1"
   },
   "devDependencies": {

--- a/apps/desktop/src/bun/index.ts
+++ b/apps/desktop/src/bun/index.ts
@@ -1,4 +1,13 @@
-import { BrowserWindow, Updater } from "electrobun/bun";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { BrowserView, BrowserWindow, Updater } from "electrobun/bun";
+import { runScan, type ScanRun } from "@zpace/scanner/src/run";
+import {
+  initialScanProgress,
+  type ScanLifecycleSnapshot,
+  type ScanProgress,
+} from "@zpace/scanner/src/schema";
 
 const DEV_SERVER_PORT = 3001;
 const DEV_SERVER_URL = `http://localhost:${DEV_SERVER_PORT}`;
@@ -21,9 +30,139 @@ async function getMainViewUrl(): Promise<string> {
 
 const url = await getMainViewUrl();
 
+type DesktopScanSnapshotMessage = {
+  snapshot: ScanLifecycleSnapshot;
+};
+
+type ZpaceDesktopRPCSchema = {
+  bun: {
+    requests: {
+      getDefaultScanPath: { params: void; response: { path: string } };
+      startScan: { params: { path: string }; response: { accepted: true } };
+      cancelScan: { params: void; response: { cancelled: boolean } };
+    };
+    messages: Record<never, never>;
+  };
+  webview: {
+    requests: Record<never, never>;
+    messages: {
+      scanSnapshot: DesktopScanSnapshotMessage;
+    };
+  };
+};
+
+let activeScan: ScanRun | null = null;
+let activeScanVersion = 0;
+
+const rpc = BrowserView.defineRPC<ZpaceDesktopRPCSchema>({
+  maxRequestTime: Infinity,
+  handlers: {
+    requests: {
+      getDefaultScanPath() {
+        return { path: homedir() };
+      },
+      startScan({ path }) {
+        startDesktopScan(path);
+        return { accepted: true };
+      },
+      cancelScan() {
+        if (!activeScan) return { cancelled: false };
+        activeScan.cancel();
+        activeScan = null;
+        activeScanVersion += 1;
+        rpc.send.scanSnapshot({
+          snapshot: {
+            state: "cancelled",
+            progress: { ...initialScanProgress, currentPath: null },
+            result: null,
+            error: null,
+          },
+        });
+        return { cancelled: true };
+      },
+    },
+    messages: {},
+  },
+});
+
+function startDesktopScan(path: string) {
+  activeScan?.cancel();
+  activeScanVersion += 1;
+  const version = activeScanVersion;
+  const targetPath = expandUserPath(path.trim() || homedir());
+
+  rpc.send.scanSnapshot({
+    snapshot: {
+      state: "starting",
+      progress: { ...initialScanProgress, currentPath: targetPath },
+      result: null,
+      error: null,
+    },
+  });
+
+  const scan = runScan({
+    path: targetPath,
+    onEvent(_event, snapshot) {
+      if (version !== activeScanVersion) return;
+      rpc.send.scanSnapshot({ snapshot: cloneSnapshot(snapshot) });
+    },
+  });
+  activeScan = scan;
+
+  void scan.completed
+    .then((result) => {
+      if (version !== activeScanVersion) return;
+      const progress = activeScan?.snapshot.progress;
+      activeScan = null;
+      rpc.send.scanSnapshot({
+        snapshot: {
+          state: "complete",
+          progress: createCompletedProgress(progress),
+          result,
+          error: null,
+        },
+      });
+    })
+    .catch((error: unknown) => {
+      if (version !== activeScanVersion) return;
+      activeScan = null;
+      rpc.send.scanSnapshot({
+        snapshot: {
+          state: "error",
+          progress: { ...initialScanProgress, currentPath: null },
+          result: null,
+          error: error instanceof Error ? error.message : "Scanner failed",
+        },
+      });
+    });
+}
+
+function expandUserPath(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return join(homedir(), path.slice(2));
+  return path;
+}
+
+function cloneSnapshot(snapshot: ScanLifecycleSnapshot): ScanLifecycleSnapshot {
+  return {
+    ...snapshot,
+    progress: { ...snapshot.progress },
+  };
+}
+
+function createCompletedProgress(progress: ScanProgress | undefined): ScanProgress {
+  return {
+    pathsScanned: progress?.pathsScanned ?? 0,
+    directoriesScanned: progress?.directoriesScanned ?? 0,
+    filesScanned: progress?.filesScanned ?? 0,
+    currentPath: null,
+  };
+}
+
 new BrowserWindow({
   title: "zpace",
   url,
+  rpc,
   frame: {
     width: 1280,
     height: 820,

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -7,7 +7,8 @@
     "moduleResolution": "bundler",
     "noEmit": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@zpace/scanner/*": ["../../packages/scanner/*"]
     }
   },
   "include": ["src/**/*.ts", "electrobun.config.ts"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@zpace/env": "workspace:*",
     "@zpace/scanner": "workspace:*",
     "dotenv": "catalog:",
+    "electrobun": "^1.15.1",
     "lucide-solid": "^1.8.0",
     "solid-js": "^1.9.12",
     "tailwindcss": "^4.2.2",

--- a/apps/web/src/__tests__/desktop-bridge.test.ts
+++ b/apps/web/src/__tests__/desktop-bridge.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createBestAvailableScanSession } from "@/desktop-bridge";
+import { initialScanProgress, type ScanLifecycleSnapshot } from "@zpace/scanner/src/schema";
+
+afterEach(() => {
+  vi.useRealTimers();
+  delete window.__zpaceDesktopRPC;
+  delete window.__electrobun;
+});
+
+describe("createBestAvailableScanSession", () => {
+  test("falls back to fixture mode outside Electrobun", async () => {
+    vi.useFakeTimers();
+    const runtime = await createBestAvailableScanSession();
+
+    expect(runtime.mode).toBe("fixture");
+    expect(runtime.defaultPath).toBe("~");
+    expect(runtime.session.snapshot().result?.root.name).toBe("zpace");
+  });
+
+  test("uses desktop RPC when it is already available", async () => {
+    const listeners: Array<(payload: { snapshot: ScanLifecycleSnapshot }) => void> = [];
+    const startScan = vi.fn(async () => {
+      listeners.forEach((listener) =>
+        listener({
+          snapshot: {
+            state: "complete",
+            progress: { ...initialScanProgress, currentPath: null },
+            result: null,
+            error: null,
+          },
+        }),
+      );
+      return { accepted: true as const };
+    });
+    const cancelScan = vi.fn(async () => ({ cancelled: true }));
+
+    window.__zpaceDesktopRPC = {
+      request: {
+        getDefaultScanPath: vi.fn(async () => ({ path: "/Users/erik" })),
+        startScan,
+        cancelScan,
+      },
+      addMessageListener(_message, listener) {
+        listeners.push(listener);
+      },
+    };
+
+    const runtime = await createBestAvailableScanSession();
+    expect(runtime.mode).toBe("desktop");
+    expect(runtime.defaultPath).toBe("/Users/erik");
+
+    runtime.session.startRescan("/tmp/zpace");
+
+    expect(startScan).toHaveBeenCalledWith({ path: "/tmp/zpace" });
+    expect(runtime.session.snapshot().state).toBe("complete");
+  });
+});

--- a/apps/web/src/components/__tests__/scan-list.test.tsx
+++ b/apps/web/src/components/__tests__/scan-list.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { render } from "solid-js/web";
+import type { ScanNode } from "@zpace/scanner/src/schema";
 
 import { ScanList } from "@/components/scan-list";
 import { fixtureScanResult } from "@/fixtures/scan-result";
@@ -63,12 +64,29 @@ describe("ScanList", () => {
     expect(host.textContent).toContain("Developer artifacts");
     cleanup(dispose, host);
   });
+
+  test("adds and removes rows through queue controls", () => {
+    const added: ScanNode[] = [];
+    const removed: string[] = [];
+    const { dispose, host } = renderScanList({
+      queuedPaths: new Set(["/Users/erik/Projects/zpace/node_modules"]),
+      onAddToQueue: (node) => added.push(node),
+      onRemoveFromQueue: (path) => removed.push(path),
+    });
+
+    clickRowQueueButton(host, "package.json");
+    clickRowQueueButton(host, "node_modules");
+
+    expect(added.map((node) => node.path)).toEqual(["/Users/erik/Projects/zpace/package.json"]);
+    expect(removed).toEqual(["/Users/erik/Projects/zpace/node_modules"]);
+    cleanup(dispose, host);
+  });
 });
 
-function renderScanList() {
+function renderScanList(props: Partial<Parameters<typeof ScanList>[0]> = {}) {
   const host = document.createElement("div");
   document.body.append(host);
-  const dispose = render(() => <ScanList root={fixtureScanResult.root} />, host);
+  const dispose = render(() => <ScanList root={fixtureScanResult.root} {...props} />, host);
   return { dispose, host };
 }
 
@@ -97,4 +115,12 @@ function rowNames(host: HTMLElement): string[] {
   return Array.from(host.querySelectorAll("[data-scan-row]")).map(
     (row) => row.getAttribute("data-scan-row") ?? "",
   );
+}
+
+function clickRowQueueButton(host: HTMLElement, rowName: string) {
+  const row = host.querySelector(`[data-scan-row="${rowName}"]`);
+  expect(row).toBeDefined();
+  const button = row?.querySelector("button[aria-pressed]");
+  expect(button).toBeDefined();
+  button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 }

--- a/apps/web/src/components/scan-list.tsx
+++ b/apps/web/src/components/scan-list.tsx
@@ -8,6 +8,8 @@ import {
   Folder,
   Link,
   Package,
+  Plus,
+  X,
 } from "lucide-solid";
 import { createMemo, createSignal, For, Show } from "solid-js";
 
@@ -19,6 +21,9 @@ import {
 
 interface ScanListProps {
   root: ScanNode;
+  queuedPaths?: ReadonlySet<string>;
+  onAddToQueue?: (node: ScanNode) => void;
+  onRemoveFromQueue?: (path: string) => void;
 }
 
 type SortKey = "name" | "logicalSize" | "allocatedSize" | "type" | "category" | "risk";
@@ -149,18 +154,19 @@ export function ScanList(props: ScanListProps) {
         </div>
       </div>
 
-      <div class="grid grid-cols-[minmax(0,1fr)_7rem_7rem_10rem_8rem] gap-4 border-b border-neutral-800 px-4 py-3 text-xs font-medium uppercase text-neutral-500">
+      <div class="grid grid-cols-[minmax(0,1fr)_7rem_7rem_10rem_8rem_6rem] gap-4 border-b border-neutral-800 px-4 py-3 text-xs font-medium uppercase text-neutral-500">
         <span>Item</span>
         <span class="text-right">Logical</span>
         <span class="text-right">Allocated</span>
         <span>Classification</span>
         <span class="text-right">Status</span>
+        <span class="text-right">Queue</span>
       </div>
       <ul>
         <For each={rows()}>
           {(row) => (
             <li
-              class="grid grid-cols-[minmax(0,1fr)_7rem_7rem_10rem_8rem] gap-4 border-b border-neutral-800 px-4 py-3 last:border-b-0"
+              class="grid grid-cols-[minmax(0,1fr)_7rem_7rem_10rem_8rem_6rem] gap-4 border-b border-neutral-800 px-4 py-3 last:border-b-0"
               data-scan-row={row.node.name}
             >
               <div class="flex min-w-0 items-center gap-3">
@@ -228,6 +234,14 @@ export function ScanList(props: ScanListProps) {
                   )}
                 </Show>
               </div>
+              <div class="self-center text-right">
+                <QueueButton
+                  node={row.node}
+                  isQueued={props.queuedPaths?.has(row.node.path) ?? false}
+                  onAdd={props.onAddToQueue}
+                  onRemove={props.onRemoveFromQueue}
+                />
+              </div>
             </li>
           )}
         </For>
@@ -278,6 +292,33 @@ function NodeIcon(props: { node: ScanNode }) {
   if (props.node.type === "symlink") return <Link size={16} aria-label="Symlink" />;
   if (props.node.type === "file") return <File size={16} aria-label="File" />;
   return <Package size={16} aria-label="Other item" />;
+}
+
+function QueueButton(props: {
+  node: ScanNode;
+  isQueued: boolean;
+  onAdd?: (node: ScanNode) => void;
+  onRemove?: (path: string) => void;
+}) {
+  const canQueue = () => Boolean(props.onAdd && props.onRemove);
+
+  return (
+    <button
+      type="button"
+      class="inline-flex h-8 min-w-20 items-center justify-center gap-1.5 rounded-md border border-neutral-700 px-2 text-xs font-medium text-neutral-300 hover:bg-neutral-800 hover:text-neutral-100 disabled:cursor-not-allowed disabled:opacity-40"
+      disabled={!canQueue()}
+      aria-pressed={props.isQueued}
+      onClick={() => {
+        if (props.isQueued) props.onRemove?.(props.node.path);
+        else props.onAdd?.(props.node);
+      }}
+    >
+      <Show when={props.isQueued} fallback={<Plus size={13} aria-hidden="true" />}>
+        <X size={13} aria-hidden="true" />
+      </Show>
+      {props.isQueued ? "Remove" : "Add"}
+    </button>
+  );
 }
 
 function riskClass(risk: ScanRiskLevel): string {

--- a/apps/web/src/desktop-bridge.ts
+++ b/apps/web/src/desktop-bridge.ts
@@ -1,0 +1,126 @@
+import { initialScanProgress, type ScanLifecycleSnapshot } from "@zpace/scanner/src/schema";
+
+import { createFixtureScanSession, createScanSession, type ScanSession } from "@/scan-session";
+
+type DesktopScanSnapshotMessage = {
+  snapshot: ScanLifecycleSnapshot;
+};
+
+type ZpaceDesktopRPCSchema = {
+  bun: {
+    requests: {
+      getDefaultScanPath: { params: void; response: { path: string } };
+      startScan: { params: { path: string }; response: { accepted: true } };
+      cancelScan: { params: void; response: { cancelled: boolean } };
+    };
+    messages: Record<never, never>;
+  };
+  webview: {
+    requests: Record<never, never>;
+    messages: {
+      scanSnapshot: DesktopScanSnapshotMessage;
+    };
+  };
+};
+
+type ZpaceDesktopRPC = {
+  request: {
+    getDefaultScanPath: () => Promise<{ path: string }>;
+    startScan: (params: { path: string }) => Promise<{ accepted: true }>;
+    cancelScan: () => Promise<{ cancelled: boolean }>;
+  };
+  addMessageListener: (
+    message: "scanSnapshot",
+    listener: (payload: DesktopScanSnapshotMessage) => void,
+  ) => void;
+};
+
+declare global {
+  interface Window {
+    __electrobun?: unknown;
+    __zpaceDesktopRPC?: ZpaceDesktopRPC;
+  }
+}
+
+const idleSnapshot: ScanLifecycleSnapshot = {
+  state: "idle",
+  progress: { ...initialScanProgress },
+  result: null,
+  error: null,
+};
+
+export async function createBestAvailableScanSession(): Promise<{
+  session: ScanSession;
+  mode: "desktop" | "fixture";
+  defaultPath: string;
+}> {
+  const rpc = await getDesktopRPC();
+  if (!rpc) {
+    return {
+      session: createFixtureScanSession(),
+      mode: "fixture",
+      defaultPath: "~",
+    };
+  }
+
+  const defaultPath = await rpc.request.getDefaultScanPath().then(
+    (result) => result.path,
+    () => "~",
+  );
+  let emitSnapshot: ((snapshot: ScanLifecycleSnapshot) => void) | null = null;
+
+  rpc.addMessageListener("scanSnapshot", ({ snapshot }) => {
+    emitSnapshot?.(snapshot);
+  });
+
+  return {
+    session: createScanSession({
+      initialSnapshot: idleSnapshot,
+      start(emit, path) {
+        emitSnapshot = emit;
+        const targetPath = path?.trim() || defaultPath;
+        emit({
+          state: "starting",
+          progress: { ...initialScanProgress, currentPath: targetPath },
+          result: null,
+          error: null,
+        });
+
+        void rpc.request.startScan({ path: targetPath }).catch((error: unknown) => {
+          emit({
+            state: "error",
+            progress: { ...initialScanProgress, currentPath: null },
+            result: null,
+            error: error instanceof Error ? error.message : "Failed to start scan",
+          });
+        });
+
+        return {
+          cancel() {
+            void rpc.request.cancelScan();
+          },
+        };
+      },
+    }),
+    mode: "desktop",
+    defaultPath,
+  };
+}
+
+async function getDesktopRPC(): Promise<ZpaceDesktopRPC | null> {
+  if (window.__zpaceDesktopRPC) return window.__zpaceDesktopRPC;
+  if (!window.__electrobun) return null;
+
+  const { Electroview } = await import("electrobun/view");
+  const rpc = Electroview.defineRPC<ZpaceDesktopRPCSchema>({
+    maxRequestTime: Infinity,
+    handlers: {
+      requests: {},
+      messages: {},
+    },
+  });
+
+  new Electroview({ rpc });
+  window.__zpaceDesktopRPC = rpc as unknown as ZpaceDesktopRPC;
+  return window.__zpaceDesktopRPC;
+}

--- a/apps/web/src/fixtures/scan-result.ts
+++ b/apps/web/src/fixtures/scan-result.ts
@@ -9,7 +9,7 @@ export const fixtureScanResult = scanResultSchema.parse({
     logicalSize: 320_512,
     allocatedSize: null,
     childCount: 4,
-    status: "partial",
+    status: "complete",
     classification: null,
     children: [
       {
@@ -39,7 +39,7 @@ export const fixtureScanResult = scanResultSchema.parse({
                 logicalSize: 83_200,
                 allocatedSize: null,
                 childCount: 0,
-                status: "partial",
+                status: "complete",
                 classification: null,
                 children: [],
               },
@@ -172,8 +172,8 @@ export const fixtureScanResult = scanResultSchema.parse({
     likelyReclaimableSize: 0,
     fileCount: 5,
     folderCount: 7,
-    warningCount: 1,
-    inaccessibleCount: 1,
+    warningCount: 0,
+    inaccessibleCount: 0,
     skippedCount: 0,
     protectedCount: 0,
     freeSize: null,
@@ -223,13 +223,5 @@ export const fixtureScanResult = scanResultSchema.parse({
       },
     ],
   },
-  diagnostics: [
-    {
-      path: "/Users/erik/Projects/zpace/apps/web/src/private",
-      kind: "inaccessible",
-      severity: "warning",
-      message: "Permission denied",
-      guidance: "Grant Full Disk Access to the app or terminal running zpace, then scan again.",
-    },
-  ],
+  diagnostics: [],
 });

--- a/apps/web/src/lib/scan-presentation.test.ts
+++ b/apps/web/src/lib/scan-presentation.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "vitest";
 
 import { fixtureScanResult } from "@/fixtures/scan-result";
+import type { ScanResult } from "@zpace/scanner/src/schema";
 import {
+  createCleanupQueueItem,
+  createCleanupQueueSummary,
+  createCleanupExecutionResult,
+  canMoveCleanupQueueToTrash,
   createScanRows,
   createScanReportViewModel,
   createScanWarningRows,
@@ -25,8 +30,8 @@ describe("scan presentation", () => {
     expect(summarizeScanResult(fixtureScanResult)).toEqual([
       { label: "items", value: "4" },
       { label: "size", value: "321 KB" },
-      { label: "status", value: "partial" },
-      { label: "warnings", value: "1" },
+      { label: "status", value: "complete" },
+      { label: "warnings", value: "0" },
     ]);
   });
 
@@ -47,18 +52,20 @@ describe("scan presentation", () => {
       { label: "paths", value: "4" },
       { label: "files", value: "1" },
       { label: "size", value: "321 KB" },
-      { label: "warnings", value: "1" },
+      { label: "warnings", value: "0" },
       { label: "state", value: "complete" },
     ]);
   });
 
   test("presents incomplete scan warnings with guidance", () => {
-    expect(getIncompleteScanMessage(fixtureScanResult)).toBe(
+    const result = createWarningScanResult();
+
+    expect(getIncompleteScanMessage(result)).toBe(
       "Scan incomplete: 1 inaccessible. Reported sizes include scanned space only.",
     );
-    expect(createScanWarningRows(fixtureScanResult)).toEqual([
+    expect(createScanWarningRows(result)).toEqual([
       {
-        diagnostic: fixtureScanResult.diagnostics[0],
+        diagnostic: result.diagnostics[0],
         title: "inaccessible warning",
         detail:
           "Permission denied. Grant Full Disk Access to the app or terminal running zpace, then scan again.",
@@ -74,7 +81,7 @@ describe("scan presentation", () => {
         { label: "reclaimable", value: "0 B" },
         { label: "files", value: "5" },
         { label: "folders", value: "7" },
-        { label: "inaccessible", value: "1" },
+        { label: "inaccessible", value: "0" },
         { label: "skipped", value: "0" },
         { label: "protected", value: "0" },
         { label: "free", value: "unavailable" },
@@ -97,9 +104,108 @@ describe("scan presentation", () => {
     });
   });
 
+  test("summarizes cleanup queue selections", () => {
+    const nodeModules = fixtureScanResult.root.children.find((node) => node.name === "node_modules");
+    const packageJson = fixtureScanResult.root.children.find((node) => node.name === "package.json");
+
+    expect(nodeModules).toBeDefined();
+    expect(packageJson).toBeDefined();
+
+    const summary = createCleanupQueueSummary([
+      createCleanupQueueItem(nodeModules!),
+      createCleanupQueueItem(packageJson!),
+    ]);
+
+    expect(summary.itemCountLabel).toBe("2 items");
+    expect(summary.totalSizeLabel).toBe("83 KB");
+    expect(summary.warning).toBeNull();
+    expect(summary.items[0]).toMatchObject({
+      path: "/Users/erik/Projects/zpace/node_modules",
+      category: "Developer artifacts",
+      risk: "medium",
+      isProtected: false,
+    });
+  });
+
+  test("creates dry-run cleanup results without moving items", () => {
+    const nodeModules = fixtureScanResult.root.children.find((node) => node.name === "node_modules");
+    expect(nodeModules).toBeDefined();
+
+    const result = createCleanupExecutionResult([createCleanupQueueItem(nodeModules!)], {
+      dryRun: true,
+      trashAvailable: false,
+      now: new Date("2026-04-29T08:30:00.000Z"),
+      id: "test-run",
+    });
+
+    expect(result).toMatchObject({
+      id: "test-run",
+      completedAt: "2026-04-29T08:30:00.000Z",
+      dryRun: true,
+      itemCountLabel: "1 item",
+      totalSizeLabel: "82 KB",
+      status: "dry-run",
+    });
+    expect(result.results).toEqual([
+      {
+        path: "/Users/erik/Projects/zpace/node_modules",
+        name: "node_modules",
+        sizeLabel: "82 KB",
+        status: "dry-run",
+        message: "Dry run only. This item would be moved to Trash.",
+      },
+    ]);
+  });
+
+  test("blocks protected cleanup items from normal Trash moves", () => {
+    const protectedItem = {
+      ...createCleanupQueueItem(fixtureScanResult.root),
+      isProtected: true,
+      protectionReason: "System-adjacent path.",
+    };
+
+    expect(canMoveCleanupQueueToTrash([protectedItem])).toBe(false);
+
+    const result = createCleanupExecutionResult([protectedItem], {
+      dryRun: false,
+      trashAvailable: true,
+      now: new Date("2026-04-29T08:31:00.000Z"),
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.results[0]).toMatchObject({
+      status: "skipped",
+      message: "System-adjacent path.",
+    });
+  });
+
   test("formats byte ranges consistently", () => {
     expect(formatBytes(999)).toBe("999 B");
     expect(formatBytes(1_500)).toBe("1.5 KB");
     expect(formatBytes(20_000)).toBe("20 KB");
   });
 });
+
+function createWarningScanResult(): ScanResult {
+  return {
+    ...fixtureScanResult,
+    root: {
+      ...fixtureScanResult.root,
+      status: "partial",
+    },
+    summary: {
+      ...fixtureScanResult.summary,
+      warningCount: 1,
+      inaccessibleCount: 1,
+    },
+    diagnostics: [
+      {
+        path: "/Users/erik/Projects/zpace/apps/web/src/private",
+        kind: "inaccessible",
+        severity: "warning",
+        message: "Permission denied",
+        guidance: "Grant Full Disk Access to the app or terminal running zpace, then scan again.",
+      },
+    ],
+  };
+}

--- a/apps/web/src/lib/scan-presentation.ts
+++ b/apps/web/src/lib/scan-presentation.ts
@@ -2,7 +2,7 @@ import {
   formatBytes,
   formatOptionalBytes,
 } from "@zpace/scanner/src/presentation";
-import type { ScanNode } from "@zpace/scanner/src/schema";
+import type { ScanNode, ScanRiskLevel } from "@zpace/scanner/src/schema";
 
 export {
   createScanReportViewModel,
@@ -27,6 +27,51 @@ export interface ScanRow {
 export interface IndexedScanNode {
   node: ScanNode;
   breadcrumbs: ScanNode[];
+}
+
+export interface CleanupQueueItem {
+  path: string;
+  name: string;
+  type: ScanNode["type"];
+  logicalSize: number;
+  sizeLabel: string;
+  category: string;
+  risk: ScanRiskLevel | null;
+  recommendation: string | null;
+  isProtected: boolean;
+  protectionReason: string | null;
+}
+
+export interface CleanupQueueSummary {
+  items: CleanupQueueItem[];
+  totalSizeLabel: string;
+  itemCountLabel: string;
+  warning: string | null;
+}
+
+export interface CleanupExecutionItemResult {
+  path: string;
+  name: string;
+  sizeLabel: string;
+  status: "dry-run" | "moved" | "skipped" | "failed";
+  message: string;
+}
+
+export interface CleanupExecutionResult {
+  id: string;
+  completedAt: string;
+  dryRun: boolean;
+  itemCountLabel: string;
+  totalSizeLabel: string;
+  status: "dry-run" | "complete" | "partial" | "failed";
+  results: CleanupExecutionItemResult[];
+}
+
+export interface CleanupExecutionOptions {
+  dryRun: boolean;
+  trashAvailable: boolean;
+  now?: Date;
+  id?: string;
 }
 
 export function createScanRows(root: ScanNode): ScanRow[] {
@@ -65,4 +110,122 @@ export function buildScanNodeIndex(root: ScanNode): Map<string, IndexedScanNode>
   }
 
   return index;
+}
+
+export function createCleanupQueueItem(node: ScanNode): CleanupQueueItem {
+  return {
+    path: node.path,
+    name: node.name,
+    type: node.type,
+    logicalSize: node.logicalSize,
+    sizeLabel: formatBytes(node.logicalSize),
+    category: node.classification?.category ?? "Unclassified",
+    risk: node.classification?.risk ?? null,
+    recommendation: node.classification?.recommendation ?? null,
+    isProtected: node.classification?.isProtected ?? false,
+    protectionReason: node.classification?.protectionReason ?? null,
+  };
+}
+
+export function createCleanupQueueSummary(items: CleanupQueueItem[]): CleanupQueueSummary {
+  const totalSize = items.reduce((sum, item) => sum + item.logicalSize, 0);
+  const protectedCount = items.filter((item) => item.isProtected).length;
+  const highRiskCount = items.filter((item) => item.risk === "high").length;
+
+  return {
+    items,
+    totalSizeLabel: formatBytes(totalSize),
+    itemCountLabel: `${items.length} ${items.length === 1 ? "item" : "items"}`,
+    warning: createCleanupQueueWarning(protectedCount, highRiskCount),
+  };
+}
+
+export function canMoveCleanupQueueToTrash(items: CleanupQueueItem[]): boolean {
+  return items.length > 0 && items.every((item) => !item.isProtected);
+}
+
+export function createCleanupExecutionResult(
+  items: CleanupQueueItem[],
+  options: CleanupExecutionOptions,
+): CleanupExecutionResult {
+  const completedAt = (options.now ?? new Date()).toISOString();
+  const results = items.map((item) => createCleanupExecutionItemResult(item, options));
+  const movedCount = results.filter((result) => result.status === "moved").length;
+  const failedCount = results.filter((result) => result.status === "failed").length;
+  const skippedCount = results.filter((result) => result.status === "skipped").length;
+
+  return {
+    id: options.id ?? completedAt,
+    completedAt,
+    dryRun: options.dryRun,
+    itemCountLabel: `${items.length} ${items.length === 1 ? "item" : "items"}`,
+    totalSizeLabel: formatBytes(items.reduce((sum, item) => sum + item.logicalSize, 0)),
+    status: getCleanupExecutionStatus(options.dryRun, movedCount, failedCount, skippedCount),
+    results,
+  };
+}
+
+function createCleanupQueueWarning(protectedCount: number, highRiskCount: number): string | null {
+  if (protectedCount > 0) {
+    return `${protectedCount} protected ${protectedCount === 1 ? "item needs" : "items need"} extra review before cleanup.`;
+  }
+  if (highRiskCount > 0) {
+    return `${highRiskCount} high-risk ${highRiskCount === 1 ? "item is" : "items are"} queued.`;
+  }
+  return null;
+}
+
+function createCleanupExecutionItemResult(
+  item: CleanupQueueItem,
+  options: CleanupExecutionOptions,
+): CleanupExecutionItemResult {
+  if (item.isProtected) {
+    return {
+      path: item.path,
+      name: item.name,
+      sizeLabel: item.sizeLabel,
+      status: "skipped",
+      message: item.protectionReason ?? "Protected paths are skipped by the normal cleanup flow.",
+    };
+  }
+
+  if (options.dryRun) {
+    return {
+      path: item.path,
+      name: item.name,
+      sizeLabel: item.sizeLabel,
+      status: "dry-run",
+      message: "Dry run only. This item would be moved to Trash.",
+    };
+  }
+
+  if (!options.trashAvailable) {
+    return {
+      path: item.path,
+      name: item.name,
+      sizeLabel: item.sizeLabel,
+      status: "failed",
+      message: "Move to Trash is not available in this browser preview.",
+    };
+  }
+
+  return {
+    path: item.path,
+    name: item.name,
+    sizeLabel: item.sizeLabel,
+    status: "moved",
+    message: "Moved to Trash.",
+  };
+}
+
+function getCleanupExecutionStatus(
+  dryRun: boolean,
+  movedCount: number,
+  failedCount: number,
+  skippedCount: number,
+): CleanupExecutionResult["status"] {
+  if (dryRun) return "dry-run";
+  if (failedCount > 0 && movedCount === 0) return "failed";
+  if (failedCount > 0 || skippedCount > 0) return "partial";
+  return "complete";
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,39 +1,95 @@
 import { createFileRoute } from "@tanstack/solid-router";
-import { createMemo, For, Show } from "solid-js";
-import { AlertTriangle, RefreshCw, Square } from "lucide-solid";
+import type { ScanNode } from "@zpace/scanner/src/schema";
+import { createEffect, createMemo, createResource, createSignal, For, Show } from "solid-js";
+import { AlertTriangle, RefreshCw, Square, Trash2, X } from "lucide-solid";
 
 import { RadialUsageMap } from "@/components/radial-usage-map";
 import { ScanList } from "@/components/scan-list";
+import { createBestAvailableScanSession } from "@/desktop-bridge";
 import {
   createScanReportViewModel,
   createScanWarningRows,
+  canMoveCleanupQueueToTrash,
+  createCleanupExecutionResult,
+  createCleanupQueueItem,
+  createCleanupQueueSummary,
+  type CleanupExecutionResult,
+  type CleanupQueueItem,
   getIncompleteScanMessage,
   summarizeScanSnapshot,
 } from "@/lib/scan-presentation";
-import { createFixtureScanSession } from "@/scan-session";
+import type { ScanSession } from "@/scan-session";
 
 export const Route = createFileRoute("/")({
   component: App,
 });
 
 function App() {
-  const scan = createFixtureScanSession();
-  const snapshot = createMemo(() => scan.snapshot());
-  const root = createMemo(() => snapshot().result?.root);
-  const progress = createMemo(() => snapshot().progress);
-  const summary = createMemo(() => summarizeScanSnapshot(snapshot()));
+  const [runtime] = createResource(createBestAvailableScanSession);
+  const [scanTargetPath, setScanTargetPath] = createSignal("~");
+  const [queueItems, setQueueItems] = createSignal<CleanupQueueItem[]>([]);
+  const [cleanupHistory, setCleanupHistory] = createSignal<CleanupExecutionResult[]>([]);
+  const [isReviewingCleanup, setIsReviewingCleanup] = createSignal(false);
+  const [dryRun, setDryRun] = createSignal(false);
+  const scan = createMemo<ScanSession | null>(() => runtime()?.session ?? null);
+  createEffect(() => {
+    const nextPath = runtime()?.defaultPath;
+    if (nextPath) setScanTargetPath(nextPath);
+  });
+  const snapshot = createMemo(() => scan()?.snapshot() ?? null);
+  const root = createMemo(() => snapshot()?.result?.root);
+  const progress = createMemo(() => snapshot()?.progress ?? null);
+  const summary = createMemo(() => {
+    const currentSnapshot = snapshot();
+    return currentSnapshot ? summarizeScanSnapshot(currentSnapshot) : [];
+  });
   const incompleteMessage = createMemo(() => {
-    const result = snapshot().result;
+    const result = snapshot()?.result;
     return result ? getIncompleteScanMessage(result) : null;
   });
   const warningRows = createMemo(() => {
-    const result = snapshot().result;
+    const result = snapshot()?.result;
     return result ? createScanWarningRows(result) : [];
   });
   const report = createMemo(() => {
-    const result = snapshot().result;
+    const result = snapshot()?.result;
     return result ? createScanReportViewModel(result) : null;
   });
+  const queuedPaths = createMemo(() => new Set(queueItems().map((item) => item.path)));
+  const queueSummary = createMemo(() => createCleanupQueueSummary(queueItems()));
+
+  const addToQueue = (node: ScanNode) => {
+    setQueueItems((items) => {
+      if (items.some((item) => item.path === node.path)) return items;
+      return [...items, createCleanupQueueItem(node)];
+    });
+  };
+
+  const removeFromQueue = (path: string) => {
+    setQueueItems((items) => items.filter((item) => item.path !== path));
+  };
+
+  const confirmCleanup = () => {
+    const items = queueItems();
+    if (items.length === 0) return;
+    if (!dryRun() && !canMoveCleanupQueueToTrash(items)) return;
+
+    const result = createCleanupExecutionResult(items, {
+      dryRun: dryRun(),
+      trashAvailable: false,
+    });
+    setCleanupHistory((history) => [result, ...history]);
+    setIsReviewingCleanup(false);
+
+    if (!result.dryRun) {
+      const completedPaths = new Set(
+        result.results
+          .filter((item) => item.status === "moved")
+          .map((item) => item.path),
+      );
+      setQueueItems((currentItems) => currentItems.filter((item) => !completedPaths.has(item.path)));
+    }
+  };
 
   return (
     <main class="min-h-screen bg-neutral-950 text-neutral-100">
@@ -50,8 +106,8 @@ function App() {
               <button
                 type="button"
                 class="inline-flex h-9 items-center gap-2 rounded-md border border-neutral-700 px-3 text-sm font-medium text-neutral-100 disabled:cursor-not-allowed disabled:opacity-40"
-                disabled={!scan.canRescan()}
-                onClick={scan.startRescan}
+                disabled={!scan()?.canRescan()}
+                onClick={() => scan()?.startRescan(scanTargetPath())}
               >
                 <RefreshCw size={16} aria-hidden="true" />
                 Re-scan
@@ -59,8 +115,8 @@ function App() {
               <button
                 type="button"
                 class="inline-flex h-9 items-center gap-2 rounded-md border border-red-500/60 px-3 text-sm font-medium text-red-100 disabled:cursor-not-allowed disabled:opacity-40"
-                disabled={!scan.canCancel()}
-                onClick={scan.cancel}
+                disabled={!scan()?.canCancel()}
+                onClick={() => scan()?.cancel()}
               >
                 <Square size={14} aria-hidden="true" />
                 Cancel
@@ -80,13 +136,40 @@ function App() {
         </div>
       </section>
       <div class="mx-auto max-w-5xl px-5 py-6">
+        <section class="mb-5 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+          <div class="flex flex-col gap-3 md:flex-row md:items-end">
+            <label class="min-w-0 flex-1 text-sm text-neutral-400">
+              Scan path
+              <input
+                class="mt-1 h-10 w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 text-sm text-neutral-100"
+                value={scanTargetPath()}
+                disabled={!scan()?.canRescan()}
+                onInput={(event) => setScanTargetPath(event.currentTarget.value)}
+              />
+            </label>
+            <button
+              type="button"
+              class="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-emerald-500/60 px-3 text-sm font-medium text-emerald-100 disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={!scan()?.canRescan()}
+              onClick={() => scan()?.startRescan(scanTargetPath())}
+            >
+              <RefreshCw size={16} aria-hidden="true" />
+              Scan
+            </button>
+          </div>
+          <p class="mt-2 text-xs text-neutral-500">
+            {runtime()?.mode === "desktop"
+              ? "Desktop mode: scans run through the native Zig scanner."
+              : "Browser preview: scans use fixture data. Run the desktop app for local disk scans."}
+          </p>
+        </section>
         <div class="mb-4 h-2 overflow-hidden rounded-full bg-neutral-800">
           <div
             class="h-full bg-emerald-400 transition-all"
-            style={{ width: `${Math.min(100, progress().pathsScanned * 25)}%` }}
+            style={{ width: `${Math.min(100, (progress()?.pathsScanned ?? 0) * 25)}%` }}
           />
         </div>
-        <Show when={progress().currentPath}>
+        <Show when={progress()?.currentPath}>
           {(currentPath) => <p class="mb-4 truncate text-sm text-neutral-400">{currentPath()}</p>}
         </Show>
         <Show when={incompleteMessage()}>
@@ -135,12 +218,266 @@ function App() {
                 )}
               </Show>
               <RadialUsageMap root={scanRoot()} />
-              <ScanList root={scanRoot()} />
+              <CleanupQueue
+                summary={queueSummary()}
+                onRemove={removeFromQueue}
+                onClear={() => setQueueItems([])}
+                onReview={() => setIsReviewingCleanup(true)}
+              />
+              <Show when={isReviewingCleanup()}>
+                <CleanupReview
+                  summary={queueSummary()}
+                  dryRun={dryRun()}
+                  onDryRunChange={setDryRun}
+                  onCancel={() => setIsReviewingCleanup(false)}
+                  onConfirm={confirmCleanup}
+                />
+              </Show>
+              <CleanupHistory
+                history={cleanupHistory()}
+                canRescan={scan()?.canRescan() ?? false}
+                onRescan={() => scan()?.startRescan(scanTargetPath())}
+              />
+              <ScanList
+                root={scanRoot()}
+                queuedPaths={queuedPaths()}
+                onAddToQueue={addToQueue}
+                onRemoveFromQueue={removeFromQueue}
+              />
             </div>
           )}
         </Show>
       </div>
     </main>
+  );
+}
+
+function CleanupQueue(props: {
+  summary: ReturnType<typeof createCleanupQueueSummary>;
+  onRemove: (path: string) => void;
+  onClear: () => void;
+  onReview: () => void;
+}) {
+  const isEmpty = () => props.summary.items.length === 0;
+
+  return (
+    <section class="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+      <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h2 class="text-sm font-semibold text-neutral-100">Cleanup queue</h2>
+          <p class="mt-1 text-sm text-neutral-500">
+            {props.summary.itemCountLabel} selected, {props.summary.totalSizeLabel} total.
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="inline-flex h-9 items-center gap-2 rounded-md border border-neutral-700 px-3 text-sm font-medium text-neutral-100 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={isEmpty()}
+            onClick={props.onClear}
+          >
+            <X size={15} aria-hidden="true" />
+            Clear
+          </button>
+          <button
+            type="button"
+            class="inline-flex h-9 items-center gap-2 rounded-md border border-emerald-500/60 px-3 text-sm font-medium text-emerald-100 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={isEmpty()}
+            onClick={props.onReview}
+          >
+            <Trash2 size={15} aria-hidden="true" />
+            Review cleanup
+          </button>
+        </div>
+      </div>
+      <Show when={props.summary.warning}>
+        {(warning) => (
+          <p class="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
+            {warning()}
+          </p>
+        )}
+      </Show>
+      <Show
+        when={!isEmpty()}
+        fallback={<p class="mt-4 text-sm text-neutral-500">Add items from the scan list before reviewing cleanup.</p>}
+      >
+        <ul class="mt-4 divide-y divide-neutral-800">
+          <For each={props.summary.items}>
+            {(item) => (
+              <li class="flex min-w-0 items-start justify-between gap-3 py-3">
+                <div class="min-w-0">
+                  <div class="flex min-w-0 flex-wrap items-center gap-2">
+                    <p class="truncate text-sm font-medium text-neutral-100">{item.name}</p>
+                    <span class="rounded-md border border-neutral-700 px-1.5 py-0.5 text-[11px] text-neutral-300">
+                      {item.category}
+                    </span>
+                    <Show when={item.risk}>
+                      {(risk) => (
+                        <span class="rounded-md border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] text-amber-200">
+                          {risk()}
+                        </span>
+                      )}
+                    </Show>
+                    <Show when={item.isProtected}>
+                      <span class="rounded-md border border-red-500/40 bg-red-500/10 px-1.5 py-0.5 text-[11px] text-red-200">
+                        protected
+                      </span>
+                    </Show>
+                  </div>
+                  <p class="mt-1 truncate text-xs text-neutral-500">{item.path}</p>
+                  <Show when={item.recommendation}>
+                    {(recommendation) => (
+                      <p class="mt-1 line-clamp-2 text-xs text-neutral-500">{recommendation()}</p>
+                    )}
+                  </Show>
+                </div>
+                <div class="shrink-0 text-right">
+                  <p class="text-sm tabular-nums text-neutral-300">{item.sizeLabel}</p>
+                  <button
+                    type="button"
+                    class="mt-2 inline-flex h-8 items-center justify-center rounded-md border border-neutral-700 px-2 text-xs text-neutral-300 hover:bg-neutral-800 hover:text-neutral-100"
+                    onClick={() => props.onRemove(item.path)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </li>
+            )}
+          </For>
+        </ul>
+      </Show>
+    </section>
+  );
+}
+
+function CleanupReview(props: {
+  summary: ReturnType<typeof createCleanupQueueSummary>;
+  dryRun: boolean;
+  onDryRunChange: (dryRun: boolean) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const hasProtectedItems = () => props.summary.items.some((item) => item.isProtected);
+  const canConfirm = () => props.summary.items.length > 0 && (props.dryRun || !hasProtectedItems());
+
+  return (
+    <section class="rounded-lg border border-emerald-500/40 bg-neutral-900 p-4">
+      <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h2 class="text-sm font-semibold text-neutral-100">Review cleanup</h2>
+          <p class="mt-1 text-sm text-neutral-500">
+            Move {props.summary.itemCountLabel} ({props.summary.totalSizeLabel}) to Trash.
+          </p>
+        </div>
+        <label class="flex items-center gap-2 text-sm text-neutral-300">
+          <input
+            type="checkbox"
+            class="size-4 accent-emerald-400"
+            checked={props.dryRun}
+            onInput={(event) => props.onDryRunChange(event.currentTarget.checked)}
+          />
+          Dry run
+        </label>
+      </div>
+      <Show when={hasProtectedItems()}>
+        <p class="mt-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-100">
+          Protected items must be removed from the queue before moving items to Trash. Dry run remains available.
+        </p>
+      </Show>
+      <ul class="mt-4 max-h-80 divide-y divide-neutral-800 overflow-auto rounded-md border border-neutral-800">
+        <For each={props.summary.items}>
+          {(item) => (
+            <li class="grid gap-3 px-3 py-3 md:grid-cols-[minmax(0,1fr)_7rem_8rem]">
+              <div class="min-w-0">
+                <p class="truncate text-sm font-medium text-neutral-100">{item.name}</p>
+                <p class="mt-1 break-all text-xs text-neutral-500">{item.path}</p>
+                <Show when={item.protectionReason}>
+                  {(reason) => <p class="mt-1 text-xs text-red-200">{reason()}</p>}
+                </Show>
+              </div>
+              <span class="text-sm tabular-nums text-neutral-300 md:text-right">{item.sizeLabel}</span>
+              <span class={`h-fit rounded-md border px-2 py-1 text-xs ${item.isProtected ? "border-red-500/40 bg-red-500/10 text-red-200" : "border-neutral-700 text-neutral-300"}`}>
+                {item.isProtected ? "protected" : item.risk ?? "unclassified"}
+              </span>
+            </li>
+          )}
+        </For>
+      </ul>
+      <div class="mt-4 flex flex-wrap justify-end gap-2">
+        <button
+          type="button"
+          class="inline-flex h-9 items-center rounded-md border border-neutral-700 px-3 text-sm font-medium text-neutral-100"
+          onClick={props.onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="inline-flex h-9 items-center gap-2 rounded-md border border-emerald-500/60 px-3 text-sm font-medium text-emerald-100 disabled:cursor-not-allowed disabled:opacity-40"
+          disabled={!canConfirm()}
+          onClick={props.onConfirm}
+        >
+          <Trash2 size={15} aria-hidden="true" />
+          {props.dryRun ? "Run dry run" : "Move to Trash"}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function CleanupHistory(props: {
+  history: CleanupExecutionResult[];
+  canRescan: boolean;
+  onRescan: () => void;
+}) {
+  return (
+    <Show when={props.history.length > 0}>
+      <section class="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <h2 class="text-sm font-semibold text-neutral-100">Cleanup history</h2>
+          <button
+            type="button"
+            class="inline-flex h-9 items-center gap-2 rounded-md border border-neutral-700 px-3 text-sm font-medium text-neutral-100 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={!props.canRescan}
+            onClick={props.onRescan}
+          >
+            <RefreshCw size={15} aria-hidden="true" />
+            Re-scan
+          </button>
+        </div>
+        <ul class="mt-4 space-y-3">
+          <For each={props.history}>
+            {(entry) => (
+              <li class="rounded-md border border-neutral-800 p-3">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                  <p class="text-sm font-medium text-neutral-100">
+                    {entry.itemCountLabel}, {entry.totalSizeLabel}
+                  </p>
+                  <span class="rounded-md border border-neutral-700 px-2 py-1 text-xs text-neutral-300">
+                    {entry.status}
+                  </span>
+                </div>
+                <p class="mt-1 text-xs text-neutral-500">
+                  {new Date(entry.completedAt).toLocaleString()}
+                </p>
+                <ul class="mt-3 space-y-2">
+                  <For each={entry.results}>
+                    {(result) => (
+                      <li class="grid gap-2 text-sm md:grid-cols-[minmax(0,1fr)_7rem_8rem]">
+                        <span class="min-w-0 truncate text-neutral-300">{result.path}</span>
+                        <span class="tabular-nums text-neutral-500 md:text-right">{result.sizeLabel}</span>
+                        <span class="text-neutral-500">{result.status}</span>
+                        <span class="text-xs text-neutral-500 md:col-span-3">{result.message}</span>
+                      </li>
+                    )}
+                  </For>
+                </ul>
+              </li>
+            )}
+          </For>
+        </ul>
+      </section>
+    </Show>
   );
 }
 

--- a/apps/web/src/scan-session.ts
+++ b/apps/web/src/scan-session.ts
@@ -13,7 +13,7 @@ export interface ScanSession {
   snapshot: () => ScanLifecycleSnapshot;
   canCancel: () => boolean;
   canRescan: () => boolean;
-  startRescan: () => void;
+  startRescan: (path?: string) => void;
   cancel: () => void;
 }
 
@@ -25,7 +25,7 @@ export interface ScanSessionRun {
 
 export interface ScanSessionAdapter {
   initialSnapshot: ScanLifecycleSnapshot;
-  start: (emit: ScanSnapshotEmitter) => ScanSessionRun;
+  start: (emit: ScanSnapshotEmitter, path?: string) => ScanSessionRun;
 }
 
 const completeSnapshot: ScanLifecycleSnapshot = {
@@ -56,7 +56,7 @@ export function createScanSession(adapter: ScanSessionAdapter): ScanSession {
     }
   };
 
-  const startRescan = () => {
+  const startRescan = (path?: string) => {
     activeRun?.cancel();
     runVersion += 1;
 
@@ -65,7 +65,7 @@ export function createScanSession(adapter: ScanSessionAdapter): ScanSession {
     const run = adapter.start((nextSnapshot) => {
       applySnapshot(nextSnapshot, version);
       if (!isActiveScanState(nextSnapshot.state)) finishedDuringStart = true;
-    });
+    }, path);
     activeRun = finishedDuringStart ? null : run;
   };
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
     "apps/desktop": {
       "name": "desktop",
       "dependencies": {
+        "@zpace/scanner": "workspace:*",
         "electrobun": "^1.15.1",
       },
       "devDependencies": {
@@ -37,6 +38,7 @@
         "@zpace/env": "workspace:*",
         "@zpace/scanner": "workspace:*",
         "dotenv": "catalog:",
+        "electrobun": "^1.15.1",
         "lucide-solid": "^1.8.0",
         "solid-js": "^1.9.12",
         "tailwindcss": "^4.2.2",


### PR DESCRIPTION
## Summary

This PR turns the scan UI into a desktop-capable flow by adding an Electrobun RPC bridge that starts and cancels the real Zig scanner from the desktop runtime, while keeping fixture mode for standalone browser UI work. The root cause of the earlier confusion was that the web app always used bundled fixture data, so the Re-scan button could not inspect the local machine even inside the desktop shell. The fix adds a typed desktop bridge, a scan target input, fixture fallback messaging, cleanup queue/review UI, and session cleanup history without giving browser preview code native filesystem powers.

## Validation

- `bun --filter web test`
- `bun run check-types`
- `bun --filter @zpace/scanner test`
- `bun --filter web build`
- `bun --filter desktop build`
- CLI smoke scan on a temporary real directory
