### PR TITLE
[codex] improve scanner performance slices

### DIFF
--- a/apps/desktop/electrobun.config.ts
+++ b/apps/desktop/electrobun.config.ts
@@ -1,6 +1,7 @@
 import type { ElectrobunConfig } from "electrobun";
 
 const webBuildDir = "../web/dist";
+const scannerExecutable = "../../packages/scanner/native/zig-out/bin/zpace-scanner";
 
 export default {
   app: {
@@ -17,6 +18,7 @@ export default {
     },
     copy: {
       [webBuildDir]: "views/mainview",
+      [scannerExecutable]: "scanner/zpace-scanner",
     },
     watchIgnore: [`${webBuildDir}/**`],
     mac: {

--- a/apps/desktop/src/bun/index.ts
+++ b/apps/desktop/src/bun/index.ts
@@ -1,16 +1,36 @@
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
-import { BrowserView, BrowserWindow, Updater } from "electrobun/bun";
+import { ApplicationMenu, BrowserView, BrowserWindow, Updater } from "electrobun/bun";
 import { runScan, type ScanRun } from "@zpace/scanner/src/run";
 import {
-  initialScanProgress,
   type ScanLifecycleSnapshot,
   type ScanProgress,
 } from "@zpace/scanner/src/schema";
+import { createScanRuntime, type ScanRuntime } from "@zpace/scanner/src/runtime";
 
 const DEV_SERVER_PORT = 3001;
 const DEV_SERVER_URL = `http://localhost:${DEV_SERVER_PORT}`;
+const scannerSourceRoot = findScannerSourceRoot();
+const scannerExecutablePath = findScannerExecutablePath();
+const defaultScanPath = findDefaultScanPath();
+const defaultExcludedPaths = createDefaultExcludedPaths();
+
+ApplicationMenu.setApplicationMenu([
+  {
+    label: "Edit",
+    submenu: [
+      { role: "undo", accelerator: "CommandOrControl+Z" },
+      { role: "redo", accelerator: "Shift+CommandOrControl+Z" },
+      { type: "divider" },
+      { role: "cut", accelerator: "CommandOrControl+X" },
+      { role: "copy", accelerator: "CommandOrControl+C" },
+      { role: "paste", accelerator: "CommandOrControl+V" },
+      { role: "selectAll", accelerator: "CommandOrControl+A" },
+    ],
+  },
+]);
 
 // Check if the web dev server is running for HMR
 async function getMainViewUrl(): Promise<string> {
@@ -37,8 +57,11 @@ type DesktopScanSnapshotMessage = {
 type ZpaceDesktopRPCSchema = {
   bun: {
     requests: {
-      getDefaultScanPath: { params: void; response: { path: string } };
-      startScan: { params: { path: string }; response: { accepted: true } };
+      getDefaultScanPath: { params: void; response: { path: string; homePath: string; excludedPaths: string[] } };
+      startScan: {
+        params: { path: string; excludedPaths?: string[]; deepScanGenerated?: boolean };
+        response: { accepted: true };
+      };
       cancelScan: { params: void; response: { cancelled: boolean } };
     };
     messages: Record<never, never>;
@@ -51,91 +74,77 @@ type ZpaceDesktopRPCSchema = {
   };
 };
 
-let activeScan: ScanRun | null = null;
-let activeScanVersion = 0;
+let scanRuntime: ScanRuntime;
 
 const rpc = BrowserView.defineRPC<ZpaceDesktopRPCSchema>({
   maxRequestTime: Infinity,
   handlers: {
     requests: {
       getDefaultScanPath() {
-        return { path: homedir() };
+        return { path: defaultScanPath, homePath: homedir(), excludedPaths: defaultExcludedPaths };
       },
-      startScan({ path }) {
-        startDesktopScan(path);
+      startScan({ path, excludedPaths, deepScanGenerated }) {
+        scanRuntime.start({
+          path: expandUserPath(path),
+          excludedPaths: (excludedPaths ?? defaultExcludedPaths).map(expandUserPath),
+          deepScanGenerated,
+        });
         return { accepted: true };
       },
       cancelScan() {
-        if (!activeScan) return { cancelled: false };
-        activeScan.cancel();
-        activeScan = null;
-        activeScanVersion += 1;
-        rpc.send.scanSnapshot({
-          snapshot: {
-            state: "cancelled",
-            progress: { ...initialScanProgress, currentPath: null },
-            result: null,
-            error: null,
-          },
-        });
-        return { cancelled: true };
+        return { cancelled: scanRuntime.cancel() };
       },
     },
     messages: {},
   },
 });
 
-function startDesktopScan(path: string) {
-  activeScan?.cancel();
-  activeScanVersion += 1;
-  const version = activeScanVersion;
-  const targetPath = expandUserPath(path.trim() || homedir());
-
-  rpc.send.scanSnapshot({
-    snapshot: {
-      state: "starting",
-      progress: { ...initialScanProgress, currentPath: targetPath },
-      result: null,
-      error: null,
-    },
-  });
-
-  const scan = runScan({
-    path: targetPath,
-    onEvent(_event, snapshot) {
-      if (version !== activeScanVersion) return;
-      rpc.send.scanSnapshot({ snapshot: cloneSnapshot(snapshot) });
-    },
-  });
-  activeScan = scan;
-
-  void scan.completed
-    .then((result) => {
-      if (version !== activeScanVersion) return;
-      const progress = activeScan?.snapshot.progress;
-      activeScan = null;
-      rpc.send.scanSnapshot({
-        snapshot: {
-          state: "complete",
-          progress: createCompletedProgress(progress),
-          result,
-          error: null,
+scanRuntime = createScanRuntime({
+  defaultPath: defaultScanPath,
+  defaultExcludedPaths,
+  onSnapshot(snapshot) {
+    rpc.send.scanSnapshot({ snapshot });
+  },
+  adapter: {
+    start(request, emit) {
+      const effectiveExcludedPaths = filterExcludedPathsForTarget(request.path, request.excludedPaths);
+      const scan: ScanRun = runScan({
+        path: request.path,
+        scannerRoot: scannerSourceRoot,
+        scannerExecutablePath,
+        excludedPaths: effectiveExcludedPaths,
+        deepScanGenerated: request.deepScanGenerated,
+        onEvent(_event, snapshot) {
+          emit(snapshot);
         },
       });
-    })
-    .catch((error: unknown) => {
-      if (version !== activeScanVersion) return;
-      activeScan = null;
-      rpc.send.scanSnapshot({
-        snapshot: {
-          state: "error",
-          progress: { ...initialScanProgress, currentPath: null },
-          result: null,
-          error: error instanceof Error ? error.message : "Scanner failed",
+
+      void scan.completed
+        .then((result) => {
+          emit({
+            state: "complete",
+            progress: createCompletedProgress(scan.snapshot.progress),
+            result,
+            error: null,
+          });
+        })
+        .catch((error: unknown) => {
+          emit({
+            state: "error",
+            progress: createCompletedProgress(undefined),
+            result: null,
+            error: error instanceof Error ? error.message : "Scanner failed",
+          });
+        });
+
+      return {
+        cancel() {
+          scan.cancel();
         },
-      });
-    });
-}
+      };
+    },
+  },
+});
 
 function expandUserPath(path: string): string {
   if (path === "~") return homedir();
@@ -143,11 +152,80 @@ function expandUserPath(path: string): string {
   return path;
 }
 
-function cloneSnapshot(snapshot: ScanLifecycleSnapshot): ScanLifecycleSnapshot {
-  return {
-    ...snapshot,
-    progress: { ...snapshot.progress },
-  };
+function findScannerExecutablePath(): string | undefined {
+  const candidates = [
+    process.env.ZPACE_SCANNER_EXECUTABLE,
+    resolve(dirname(process.argv0), "../Resources/app/scanner/zpace-scanner"),
+    resolve(process.cwd(), "../Resources/app/scanner/zpace-scanner"),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function findScannerSourceRoot(): string | undefined {
+  const initialCwd = process.env.INIT_CWD;
+  const candidates = [
+    process.env.ZPACE_SCANNER_ROOT,
+    initialCwd ? resolve(initialCwd, "packages/scanner") : null,
+    initialCwd ? resolve(initialCwd, "../../packages/scanner") : null,
+    resolve(process.cwd(), "packages/scanner"),
+    resolve(process.cwd(), "../packages/scanner"),
+    resolve(process.cwd(), "../../packages/scanner"),
+    resolve(process.cwd(), "../../../packages/scanner"),
+    resolve(process.cwd(), "../../../../packages/scanner"),
+    resolve(process.cwd(), "../../../../../packages/scanner"),
+    resolve(process.cwd(), "../../../../../../packages/scanner"),
+    resolve(process.cwd(), "../../../../../../../packages/scanner"),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  const scannerRoot = candidates.find((candidate) =>
+    existsSync(resolve(candidate, "native/build.zig")),
+  );
+  if (!scannerRoot && !findScannerExecutablePath()) {
+    throw new Error(
+      `Could not locate the bundled zpace scanner executable or packages/scanner/native/build.zig from ${process.cwd()}. Set ZPACE_SCANNER_EXECUTABLE or ZPACE_SCANNER_ROOT.`,
+    );
+  }
+  return scannerRoot;
+}
+
+function findDefaultScanPath(): string {
+  const initialCwd = process.env.INIT_CWD;
+  const candidates = [
+    process.env.ZPACE_DEFAULT_SCAN_PATH,
+    initialCwd && existsSync(resolve(initialCwd, "package.json")) ? initialCwd : null,
+    scannerSourceRoot ? resolve(scannerSourceRoot, "../..") : null,
+    homedir(),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  return candidates[0] ?? homedir();
+}
+
+function createDefaultExcludedPaths(): string[] {
+  const home = homedir();
+  return [
+    join(home, "Library/CloudStorage"),
+    join(home, "Library/Mobile Documents"),
+    join(home, "Library/Group Containers/group.com.apple.FileProvider"),
+    join(home, "Library/Application Support/FileProvider"),
+    join(home, "Library/Metadata/CoreSpotlight"),
+  ].filter((path) => existsSync(path));
+}
+
+function filterExcludedPathsForTarget(targetPath: string, excludedPaths: string[]): string[] {
+  const normalizedTarget = normalizePath(targetPath);
+  return excludedPaths
+    .map(normalizePath)
+    .filter((path) => path.length > 0)
+    .filter((path) => !isSameOrChildPath(normalizedTarget, path));
+}
+
+function isSameOrChildPath(path: string, parentPath: string): boolean {
+  return path === parentPath || path.startsWith(`${parentPath}/`);
+}
+
+function normalizePath(path: string): string {
+  return resolve(path).replace(/\/+$/, "");
 }
 
 function createCompletedProgress(progress: ScanProgress | undefined): ScanProgress {
@@ -155,6 +233,7 @@ function createCompletedProgress(progress: ScanProgress | undefined): ScanProgre
     pathsScanned: progress?.pathsScanned ?? 0,
     directoriesScanned: progress?.directoriesScanned ?? 0,
     filesScanned: progress?.filesScanned ?? 0,
+    logicalSizeScanned: progress?.logicalSizeScanned ?? 0,
     currentPath: null,
   };
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.167.22",
     "@tanstack/solid-router": "^1.168.20",
+    "@tanstack/solid-router-devtools": "^1.166.13",
     "@zpace/env": "workspace:*",
     "@zpace/scanner": "workspace:*",
     "dotenv": "catalog:",

--- a/apps/web/src/__tests__/desktop-bridge.test.ts
+++ b/apps/web/src/__tests__/desktop-bridge.test.ts
@@ -16,6 +16,7 @@ describe("createBestAvailableScanSession", () => {
 
     expect(runtime.mode).toBe("fixture");
     expect(runtime.defaultPath).toBe("~");
+    expect(runtime.defaultExcludedPaths).toEqual([]);
     expect(runtime.session.snapshot().result?.root.name).toBe("zpace");
   });
 
@@ -38,7 +39,11 @@ describe("createBestAvailableScanSession", () => {
 
     window.__zpaceDesktopRPC = {
       request: {
-        getDefaultScanPath: vi.fn(async () => ({ path: "/Users/erik" })),
+        getDefaultScanPath: vi.fn(async () => ({
+          path: "/Users/erik/Projects/zpace",
+          homePath: "/Users/erik",
+          excludedPaths: ["/Users/erik/Library/CloudStorage"],
+        })),
         startScan,
         cancelScan,
       },
@@ -49,11 +54,17 @@ describe("createBestAvailableScanSession", () => {
 
     const runtime = await createBestAvailableScanSession();
     expect(runtime.mode).toBe("desktop");
-    expect(runtime.defaultPath).toBe("/Users/erik");
+    expect(runtime.defaultPath).toBe("/Users/erik/Projects/zpace");
+    expect(runtime.homePath).toBe("/Users/erik");
+    expect(runtime.defaultExcludedPaths).toEqual(["/Users/erik/Library/CloudStorage"]);
 
-    runtime.session.startRescan("/tmp/zpace");
+    runtime.session.startRescan("/tmp/zpace", ["/tmp/zpace/.git"]);
 
-    expect(startScan).toHaveBeenCalledWith({ path: "/tmp/zpace" });
+    expect(startScan).toHaveBeenCalledWith({
+      path: "/tmp/zpace",
+      excludedPaths: ["/tmp/zpace/.git"],
+      deepScanGenerated: false,
+    });
     expect(runtime.session.snapshot().state).toBe("complete");
   });
 });

--- a/apps/web/src/__tests__/scan-session.test.ts
+++ b/apps/web/src/__tests__/scan-session.test.ts
@@ -58,7 +58,7 @@ describe("createScanSession", () => {
     let emitSnapshot: ScanSnapshotEmitter | null = null;
     const adapter: ScanSessionAdapter = {
       initialSnapshot: idleSnapshot,
-      start(emit) {
+      start(_request, emit) {
         emitSnapshot = emit;
         emit(createSnapshot("running", { ...initialScanProgress, currentPath: "/tmp/zpace" }));
         return { cancel: vi.fn() };
@@ -86,7 +86,7 @@ describe("createScanSession", () => {
     const cancel = vi.fn();
     const adapter: ScanSessionAdapter = {
       initialSnapshot: idleSnapshot,
-      start(emit) {
+      start(_request, emit) {
         emitSnapshot = emit;
         emit(createSnapshot("running", { ...initialScanProgress, currentPath: "/tmp/zpace" }));
         return { cancel };

--- a/apps/web/src/components/scan-list.tsx
+++ b/apps/web/src/components/scan-list.tsx
@@ -24,6 +24,7 @@ interface ScanListProps {
   queuedPaths?: ReadonlySet<string>;
   onAddToQueue?: (node: ScanNode) => void;
   onRemoveFromQueue?: (path: string) => void;
+  onDeepScan?: (path: string) => void;
 }
 
 type SortKey = "name" | "logicalSize" | "allocatedSize" | "type" | "category" | "risk";
@@ -232,6 +233,15 @@ export function ScanList(props: ScanListProps) {
                   {(childCountLabel) => (
                     <p class="mt-1 text-xs text-neutral-500">{childCountLabel()}</p>
                   )}
+                </Show>
+                <Show when={row.node.childrenTruncated && props.onDeepScan}>
+                  <button
+                    type="button"
+                    class="mt-2 inline-flex h-7 items-center justify-center rounded-md border border-neutral-700 px-2 text-xs text-neutral-300 hover:bg-neutral-800 hover:text-neutral-100"
+                    onClick={() => props.onDeepScan?.(row.node.path)}
+                  >
+                    Deep scan
+                  </button>
                 </Show>
               </div>
               <div class="self-center text-right">

--- a/apps/web/src/desktop-bridge.ts
+++ b/apps/web/src/desktop-bridge.ts
@@ -9,8 +9,11 @@ type DesktopScanSnapshotMessage = {
 type ZpaceDesktopRPCSchema = {
   bun: {
     requests: {
-      getDefaultScanPath: { params: void; response: { path: string } };
-      startScan: { params: { path: string }; response: { accepted: true } };
+      getDefaultScanPath: { params: void; response: { path: string; homePath: string; excludedPaths: string[] } };
+      startScan: {
+        params: { path: string; excludedPaths?: string[]; deepScanGenerated?: boolean };
+        response: { accepted: true };
+      };
       cancelScan: { params: void; response: { cancelled: boolean } };
     };
     messages: Record<never, never>;
@@ -25,8 +28,12 @@ type ZpaceDesktopRPCSchema = {
 
 type ZpaceDesktopRPC = {
   request: {
-    getDefaultScanPath: () => Promise<{ path: string }>;
-    startScan: (params: { path: string }) => Promise<{ accepted: true }>;
+    getDefaultScanPath: () => Promise<{ path: string; homePath: string; excludedPaths: string[] }>;
+    startScan: (params: {
+      path: string;
+      excludedPaths?: string[];
+      deepScanGenerated?: boolean;
+    }) => Promise<{ accepted: true }>;
     cancelScan: () => Promise<{ cancelled: boolean }>;
   };
   addMessageListener: (
@@ -53,6 +60,8 @@ export async function createBestAvailableScanSession(): Promise<{
   session: ScanSession;
   mode: "desktop" | "fixture";
   defaultPath: string;
+  homePath: string | null;
+  defaultExcludedPaths: string[];
 }> {
   const rpc = await getDesktopRPC();
   if (!rpc) {
@@ -60,13 +69,16 @@ export async function createBestAvailableScanSession(): Promise<{
       session: createFixtureScanSession(),
       mode: "fixture",
       defaultPath: "~",
+      homePath: null,
+      defaultExcludedPaths: [],
     };
   }
 
-  const defaultPath = await rpc.request.getDefaultScanPath().then(
-    (result) => result.path,
-    () => "~",
-  );
+  const defaultPaths = await rpc.request.getDefaultScanPath().catch(() => ({
+    path: "~",
+    homePath: "~",
+    excludedPaths: [],
+  }));
   let emitSnapshot: ((snapshot: ScanLifecycleSnapshot) => void) | null = null;
 
   rpc.addMessageListener("scanSnapshot", ({ snapshot }) => {
@@ -74,36 +86,40 @@ export async function createBestAvailableScanSession(): Promise<{
   });
 
   return {
-    session: createScanSession({
-      initialSnapshot: idleSnapshot,
-      start(emit, path) {
-        emitSnapshot = emit;
-        const targetPath = path?.trim() || defaultPath;
-        emit({
-          state: "starting",
-          progress: { ...initialScanProgress, currentPath: targetPath },
-          result: null,
-          error: null,
-        });
+    session: createScanSession(
+      {
+        initialSnapshot: idleSnapshot,
+        start(request, emit) {
+          emitSnapshot = emit;
 
-        void rpc.request.startScan({ path: targetPath }).catch((error: unknown) => {
-          emit({
-            state: "error",
-            progress: { ...initialScanProgress, currentPath: null },
-            result: null,
-            error: error instanceof Error ? error.message : "Failed to start scan",
-          });
-        });
+          void rpc.request
+            .startScan({
+              path: request.path,
+              excludedPaths: request.excludedPaths,
+              deepScanGenerated: request.deepScanGenerated,
+            })
+            .catch((error: unknown) => {
+              emit({
+                state: "error",
+                progress: { ...initialScanProgress, currentPath: null },
+                result: null,
+                error: error instanceof Error ? error.message : "Failed to start scan",
+              });
+            });
 
-        return {
-          cancel() {
-            void rpc.request.cancelScan();
-          },
-        };
+          return {
+            cancel() {
+              void rpc.request.cancelScan();
+            },
+          };
+        },
       },
-    }),
+      { path: defaultPaths.path, excludedPaths: defaultPaths.excludedPaths },
+    ),
     mode: "desktop",
-    defaultPath,
+    defaultPath: defaultPaths.path,
+    homePath: defaultPaths.homePath,
+    defaultExcludedPaths: defaultPaths.excludedPaths,
   };
 }
 

--- a/apps/web/src/lib/scan-presentation.test.ts
+++ b/apps/web/src/lib/scan-presentation.test.ts
@@ -43,6 +43,7 @@ describe("scan presentation", () => {
           pathsScanned: 4,
           directoriesScanned: 3,
           filesScanned: 1,
+          logicalSizeScanned: fixtureScanResult.root.logicalSize,
           currentPath: null,
         },
         result: fixtureScanResult,

--- a/apps/web/src/lib/scan-presentation.ts
+++ b/apps/web/src/lib/scan-presentation.ts
@@ -79,7 +79,7 @@ export function createScanRows(root: ScanNode): ScanRow[] {
     node,
     sizeLabel: formatBytes(node.logicalSize),
     allocatedSizeLabel: formatOptionalBytes(node.allocatedSize),
-    childCountLabel: node.childCount > 0 ? `${node.childCount} children` : null,
+    childCountLabel: formatChildCountLabel(node),
   }));
 }
 
@@ -88,7 +88,7 @@ export function createChildScanRows(root: ScanNode): ScanRow[] {
     node,
     sizeLabel: formatBytes(node.logicalSize),
     allocatedSizeLabel: formatOptionalBytes(node.allocatedSize),
-    childCountLabel: node.childCount > 0 ? `${node.childCount} children` : null,
+    childCountLabel: formatChildCountLabel(node),
   }));
 }
 
@@ -173,6 +173,13 @@ function createCleanupQueueWarning(protectedCount: number, highRiskCount: number
     return `${highRiskCount} high-risk ${highRiskCount === 1 ? "item is" : "items are"} queued.`;
   }
   return null;
+}
+
+function formatChildCountLabel(node: ScanNode): string | null {
+  if (node.childCount === 0) return null;
+  const childLabel = `${node.childCount} ${node.childCount === 1 ? "child" : "children"}`;
+  if (!node.childrenTruncated) return childLabel;
+  return `${childLabel}, showing ${node.children.length}`;
 }
 
 function createCleanupExecutionItemResult(

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -27,6 +27,8 @@ export const Route = createFileRoute("/")({
 function App() {
   const [runtime] = createResource(createBestAvailableScanSession);
   const [scanTargetPath, setScanTargetPath] = createSignal("~");
+  const [excludedPathsText, setExcludedPathsText] = createSignal("");
+  const [deepScanGenerated, setDeepScanGenerated] = createSignal(false);
   const [queueItems, setQueueItems] = createSignal<CleanupQueueItem[]>([]);
   const [cleanupHistory, setCleanupHistory] = createSignal<CleanupExecutionResult[]>([]);
   const [isReviewingCleanup, setIsReviewingCleanup] = createSignal(false);
@@ -35,10 +37,22 @@ function App() {
   createEffect(() => {
     const nextPath = runtime()?.defaultPath;
     if (nextPath) setScanTargetPath(nextPath);
+    const defaultExcludedPaths = runtime()?.defaultExcludedPaths;
+    if (defaultExcludedPaths && excludedPathsText().trim().length === 0) {
+      setExcludedPathsText(defaultExcludedPaths.join("\n"));
+    }
   });
   const snapshot = createMemo(() => scan()?.snapshot() ?? null);
   const root = createMemo(() => snapshot()?.result?.root);
   const progress = createMemo(() => snapshot()?.progress ?? null);
+  const isScanActive = createMemo(() => {
+    const state = snapshot()?.state;
+    return state === "starting" || state === "running";
+  });
+  const scanError = createMemo(() => {
+    const currentSnapshot = snapshot();
+    return currentSnapshot?.state === "error" ? currentSnapshot.error : null;
+  });
   const summary = createMemo(() => {
     const currentSnapshot = snapshot();
     return currentSnapshot ? summarizeScanSnapshot(currentSnapshot) : [];
@@ -57,6 +71,11 @@ function App() {
   });
   const queuedPaths = createMemo(() => new Set(queueItems().map((item) => item.path)));
   const queueSummary = createMemo(() => createCleanupQueueSummary(queueItems()));
+  const isHomeScanTarget = createMemo(() => {
+    const homePath = runtime()?.homePath;
+    if (!homePath) return false;
+    return normalizePath(scanTargetPath()) === normalizePath(homePath);
+  });
 
   const addToQueue = (node: ScanNode) => {
     setQueueItems((items) => {
@@ -67,6 +86,17 @@ function App() {
 
   const removeFromQueue = (path: string) => {
     setQueueItems((items) => items.filter((item) => item.path !== path));
+  };
+
+  const excludedPaths = () =>
+    excludedPathsText()
+      .split("\n")
+      .map((path) => path.trim())
+      .filter((path) => path.length > 0);
+
+  const startScan = (path = scanTargetPath(), scanGeneratedDeeply = deepScanGenerated()) => {
+    setScanTargetPath(path);
+    scan()?.startRescan(path, excludedPaths(), scanGeneratedDeeply);
   };
 
   const confirmCleanup = () => {
@@ -107,7 +137,7 @@ function App() {
                 type="button"
                 class="inline-flex h-9 items-center gap-2 rounded-md border border-neutral-700 px-3 text-sm font-medium text-neutral-100 disabled:cursor-not-allowed disabled:opacity-40"
                 disabled={!scan()?.canRescan()}
-                onClick={() => scan()?.startRescan(scanTargetPath())}
+                onClick={() => startScan()}
               >
                 <RefreshCw size={16} aria-hidden="true" />
                 Re-scan
@@ -151,7 +181,7 @@ function App() {
               type="button"
               class="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-emerald-500/60 px-3 text-sm font-medium text-emerald-100 disabled:cursor-not-allowed disabled:opacity-40"
               disabled={!scan()?.canRescan()}
-              onClick={() => scan()?.startRescan(scanTargetPath())}
+              onClick={() => startScan()}
             >
               <RefreshCw size={16} aria-hidden="true" />
               Scan
@@ -162,15 +192,73 @@ function App() {
               ? "Desktop mode: scans run through the native Zig scanner."
               : "Browser preview: scans use fixture data. Run the desktop app for local disk scans."}
           </p>
+          <label class="mt-4 block text-sm text-neutral-400">
+            Excluded paths
+            <textarea
+              class="mt-1 min-h-24 w-full resize-y rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 font-mono text-xs text-neutral-100"
+              value={excludedPathsText()}
+              disabled={!scan()?.canRescan()}
+              onInput={(event) => setExcludedPathsText(event.currentTarget.value)}
+              spellcheck={false}
+            />
+          </label>
+          <p class="mt-2 text-xs text-neutral-500">
+            One path per line. Excluded paths are reported as skipped and can be scanned directly later.
+          </p>
+          <label class="mt-3 flex items-start gap-2 text-sm text-neutral-300">
+            <input
+              type="checkbox"
+              class="mt-0.5 size-4 accent-emerald-400"
+              checked={deepScanGenerated()}
+              disabled={!scan()?.canRescan()}
+              onChange={(event) => setDeepScanGenerated(event.currentTarget.checked)}
+            />
+            <span>
+              Deep scan generated folders
+              <span class="block text-xs text-neutral-500">
+                Exact dependency folder sizes and descendant counts; slower on large package trees.
+              </span>
+            </span>
+          </label>
+          <Show when={isHomeScanTarget()}>
+            <p class="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
+              Home-folder scans can touch millions of files. Default excludes skip cloud mirrors and Spotlight metadata; remove paths here if you need them included.
+            </p>
+          </Show>
         </section>
-        <div class="mb-4 h-2 overflow-hidden rounded-full bg-neutral-800">
-          <div
-            class="h-full bg-emerald-400 transition-all"
-            style={{ width: `${Math.min(100, (progress()?.pathsScanned ?? 0) * 25)}%` }}
-          />
+        <div
+          class="mb-4 h-2 overflow-hidden rounded-full bg-neutral-800"
+          role="progressbar"
+          aria-busy={isScanActive()}
+        >
+          <Show
+            when={isScanActive()}
+            fallback={
+              <div
+                class="h-full rounded-full bg-emerald-400 transition-all"
+                style={{ width: snapshot()?.state === "complete" ? "100%" : "0%" }}
+              />
+            }
+          >
+            <div class="zpace-progress-indeterminate h-full rounded-full bg-emerald-400" />
+          </Show>
         </div>
         <Show when={progress()?.currentPath}>
           {(currentPath) => <p class="mb-4 truncate text-sm text-neutral-400">{currentPath()}</p>}
+        </Show>
+        <Show when={scanError()}>
+          {(error) => (
+            <section class="mb-5 rounded-lg border border-red-500/40 bg-red-500/10 p-4 text-red-50">
+              <div class="flex gap-3">
+                <AlertTriangle class="mt-0.5 shrink-0 text-red-300" size={18} aria-hidden="true" />
+                <div class="min-w-0">
+                  <h2 class="text-sm font-semibold">Scan failed</h2>
+                  <p class="mt-2 break-words text-sm text-red-100/90">{error()}</p>
+                  <p class="mt-2 break-all text-xs text-red-100/70">Path: {scanTargetPath()}</p>
+                </div>
+              </div>
+            </section>
+          )}
         </Show>
         <Show when={incompleteMessage()}>
           {(message) => (
@@ -236,13 +324,14 @@ function App() {
               <CleanupHistory
                 history={cleanupHistory()}
                 canRescan={scan()?.canRescan() ?? false}
-                onRescan={() => scan()?.startRescan(scanTargetPath())}
+                onRescan={() => startScan()}
               />
               <ScanList
                 root={scanRoot()}
                 queuedPaths={queuedPaths()}
                 onAddToQueue={addToQueue}
                 onRemoveFromQueue={removeFromQueue}
+                onDeepScan={(path) => startScan(path, true)}
               />
             </div>
           )}
@@ -250,6 +339,10 @@ function App() {
       </div>
     </main>
   );
+}
+
+function normalizePath(path: string): string {
+  return path.trim().replace(/\/+$/, "");
 }
 
 function CleanupQueue(props: {

--- a/apps/web/src/scan-session.ts
+++ b/apps/web/src/scan-session.ts
@@ -2,6 +2,14 @@ import { createSignal } from "solid-js";
 
 import { fixtureScanResult } from "@/fixtures/scan-result";
 import {
+  cloneSnapshot,
+  createScanRuntime,
+  type ResolvedScanRuntimeRequest,
+  type ScanRuntime,
+  type ScanRuntimeRun,
+  type ScanSnapshotEmitter,
+} from "@zpace/scanner/src/runtime";
+import {
   initialScanProgress,
   type ScanLifecycleSnapshot,
   type ScanLifecycleState,
@@ -13,19 +21,16 @@ export interface ScanSession {
   snapshot: () => ScanLifecycleSnapshot;
   canCancel: () => boolean;
   canRescan: () => boolean;
-  startRescan: (path?: string) => void;
-  cancel: () => void;
-}
-
-export type ScanSnapshotEmitter = (snapshot: ScanLifecycleSnapshot) => void;
-
-export interface ScanSessionRun {
+  startRescan: (path?: string, excludedPaths?: string[], deepScanGenerated?: boolean) => void;
   cancel: () => void;
 }
 
 export interface ScanSessionAdapter {
   initialSnapshot: ScanLifecycleSnapshot;
-  start: (emit: ScanSnapshotEmitter, path?: string) => ScanSessionRun;
+  start: (
+    request: ResolvedScanRuntimeRequest,
+    emit: ScanSnapshotEmitter,
+  ) => ScanRuntimeRun;
 }
 
 const completeSnapshot: ScanLifecycleSnapshot = {
@@ -34,56 +39,48 @@ const completeSnapshot: ScanLifecycleSnapshot = {
     pathsScanned: fixtureScanResult.root.childCount + 1,
     directoriesScanned: 3,
     filesScanned: 1,
+    logicalSizeScanned: fixtureScanResult.root.logicalSize,
     currentPath: null,
   },
   result: fixtureScanResult,
   error: null,
 };
 
-export function createScanSession(adapter: ScanSessionAdapter): ScanSession {
+export function createScanSession(
+  adapter: ScanSessionAdapter,
+  defaults: { path?: string; excludedPaths?: string[] } = {},
+): ScanSession {
   const [snapshot, setSnapshot] = createSignal<ScanLifecycleSnapshot>(
     cloneSnapshot(adapter.initialSnapshot),
   );
-  let activeRun: ScanSessionRun | null = null;
-  let runVersion = 0;
+  const runtime: ScanRuntime = createScanRuntime({
+    adapter: {
+      start(request, emit) {
+        return adapter.start(request, emit);
+      },
+    },
+    initialSnapshot: adapter.initialSnapshot,
+    defaultPath: defaults.path ?? "~",
+    defaultExcludedPaths: defaults.excludedPaths ?? [],
+    onSnapshot: setSnapshot,
+  });
 
-  const applySnapshot = (nextSnapshot: ScanLifecycleSnapshot, version: number) => {
-    if (version !== runVersion) return;
-
-    setSnapshot(cloneSnapshot(nextSnapshot));
-    if (!isActiveScanState(nextSnapshot.state)) {
-      activeRun = null;
-    }
-  };
-
-  const startRescan = (path?: string) => {
-    activeRun?.cancel();
-    runVersion += 1;
-
-    const version = runVersion;
-    let finishedDuringStart = false;
-    const run = adapter.start((nextSnapshot) => {
-      applySnapshot(nextSnapshot, version);
-      if (!isActiveScanState(nextSnapshot.state)) finishedDuringStart = true;
-    }, path);
-    activeRun = finishedDuringStart ? null : run;
-  };
-
-  const cancel = () => {
-    if (!isActiveScanState(snapshot().state)) return;
-
-    activeRun?.cancel();
-    activeRun = null;
-    runVersion += 1;
-    setSnapshot(createCancelledSnapshot(snapshot()));
+  const startRescan = (path?: string, excludedPaths?: string[], deepScanGenerated?: boolean) => {
+    runtime.start({
+      path,
+      excludedPaths,
+      deepScanGenerated,
+    });
   };
 
   return {
     snapshot,
-    canCancel: () => isActiveScanState(snapshot().state),
-    canRescan: () => !isActiveScanState(snapshot().state),
+    canCancel: () => runtime.canCancel(),
+    canRescan: () => runtime.canRescan(),
     startRescan,
-    cancel,
+    cancel() {
+      runtime.cancel();
+    },
   };
 }
 
@@ -94,7 +91,7 @@ export function createFixtureScanSession(): ScanSession {
 export function createFixtureScanSessionAdapter(): ScanSessionAdapter {
   return {
     initialSnapshot: completeSnapshot,
-    start(emit) {
+    start(_request, emit) {
       let timer: ReturnType<typeof setInterval> | null = null;
 
       const clearTimer = () => {
@@ -115,18 +112,21 @@ export function createFixtureScanSessionAdapter(): ScanSessionAdapter {
           pathsScanned: 1,
           directoriesScanned: 1,
           filesScanned: 0,
+          logicalSizeScanned: 0,
           currentPath: fixtureScanResult.root.path,
         },
         {
           pathsScanned: 2,
           directoriesScanned: 2,
           filesScanned: 0,
+          logicalSizeScanned: 0,
           currentPath: fixtureScanResult.root.children[0]?.path ?? fixtureScanResult.root.path,
         },
         {
           pathsScanned: fixtureScanResult.root.childCount + 1,
           directoriesScanned: 3,
           filesScanned: 1,
+          logicalSizeScanned: fixtureScanResult.root.logicalSize,
           currentPath: null,
         },
       ];
@@ -169,19 +169,4 @@ function createSnapshot(
     result,
     error: null,
   };
-}
-
-function createCancelledSnapshot(snapshot: ScanLifecycleSnapshot): ScanLifecycleSnapshot {
-  return createSnapshot("cancelled", { ...snapshot.progress, currentPath: null });
-}
-
-function cloneSnapshot(snapshot: ScanLifecycleSnapshot): ScanLifecycleSnapshot {
-  return {
-    ...snapshot,
-    progress: { ...snapshot.progress },
-  };
-}
-
-function isActiveScanState(state: ScanLifecycleState): boolean {
-  return state === "starting" || state === "running";
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3,3 +3,18 @@
 body {
   @apply bg-neutral-950 text-neutral-100;
 }
+
+.zpace-progress-indeterminate {
+  width: 35%;
+  animation: zpace-progress-slide 1.15s ease-in-out infinite;
+}
+
+@keyframes zpace-progress-slide {
+  0% {
+    transform: translateX(-120%);
+  }
+
+  100% {
+    transform: translateX(320%);
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/router-plugin": "^1.167.22",
         "@tanstack/solid-router": "^1.168.20",
+        "@tanstack/solid-router-devtools": "^1.166.13",
         "@zpace/env": "workspace:*",
         "@zpace/scanner": "workspace:*",
         "dotenv": "catalog:",
@@ -256,6 +257,8 @@
 
     "@tanstack/router-core": ["@tanstack/router-core@1.168.17", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-VDq7HCqRK3sdpxoETwYoTXTaYi+OVQC197g1fdzaiZBUmhntfjn+PQc15OzTqNNhf8Menk6r6ftmuphybMKdig=="],
 
+    "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.3", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg=="],
+
     "@tanstack/router-generator": ["@tanstack/router-generator@1.166.36", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.17", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "jiti": "^2.6.1", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^3.24.2" } }, "sha512-ce8Sg+ONwdd483kXJBYhTcdIAjEwSlWUOkoLsgPdNUIfA05hdnd9JkNnM4X1OnzpFL8/+TBSMo4WYQp9CHhDPg=="],
 
     "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.28", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.17", "@tanstack/router-generator": "1.166.36", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^3.0.0", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.168.25", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-O23ba7JaKvx5Eu0l6iTpknu79QcdkMmoW1VtZdsZe5NoQ6dHHru6caoapDc/uOxmz7h7VYfSuLjs/UYg7EA1cA=="],
@@ -263,6 +266,8 @@
     "@tanstack/router-utils": ["@tanstack/router-utils@1.161.7", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-VkY0u7ax/GD0qU6ZLLnfPC+UMxVzxRbvZp4yV4iUSXjgJZ/siAT5/QlLm9FEDJ9QDoC0VD9W7f00tKKreUI7Ng=="],
 
     "@tanstack/solid-router": ["@tanstack/solid-router@1.168.25", "", { "dependencies": { "@solid-devtools/logger": "^0.9.4", "@solid-primitives/refs": "^1.0.8", "@solidjs/meta": "^0.29.4", "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.17", "isbot": "^5.1.22" }, "peerDependencies": { "solid-js": "^1.9.10" }, "bin": { "intent": "bin/intent.js" } }, "sha512-ZN3sqmehucBCjYgPrh+WzzPZFTvQJJfw6tT/XfGM1iKNSg+yALkzgMQsglq+8jq/nztKnyqX2cqdNpQqixiUDg=="],
+
+    "@tanstack/solid-router-devtools": ["@tanstack/solid-router-devtools@1.166.13", "", { "dependencies": { "@tanstack/router-devtools-core": "1.167.3" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "@tanstack/solid-router": "^1.168.14", "solid-js": "^1.9.10" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-0K/bhEWPuBjHjI9h9Ckc9iioHmHr/DW+rXbfETa6G+lNK9nArUgtvuVM58sITRaSmlpImm/OCMCuNkUhXrPP/w=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 
@@ -370,6 +375,8 @@
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -441,6 +448,8 @@
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,8 +34,8 @@ Useful options may include:
 
 ```bash
 zpace scan ~/Projects --json
-zpace scan ~ --max-depth 4
-zpace scan / --include-hidden
+zpace scan ~/Projects --deep-scan
+zpace scan ~ --exclude ~/Library/CloudStorage --exclude ~/Library/Mobile\ Documents
 ```
 
 ## `zpace cleanup-candidates`

--- a/docs/scanner-contract.md
+++ b/docs/scanner-contract.md
@@ -45,7 +45,7 @@ interface ScanDiagnostic {
 }
 ```
 
-`logicalSize` is aggregated recursively for directories. `allocatedSize` is returned when the platform stat data is available for the item and is `null` for directory summary rows in this first tracer slice.
+`logicalSize` is aggregated recursively for ordinary directories. Generated dependency and cache folders are summarized by default: the scanner reuses package-manager aggregate cache metadata when available, otherwise it reports fast directory metadata and skips exact descendant file/folder counts. Call `--deep-scan` when exact generated-folder bytes and descendant counts are required. `allocatedSize` is returned when the platform stat data is available for the item and is `null` for directory summary rows in this first tracer slice.
 
 `classification` is advisory metadata for recognizable storage categories, including developer artifacts and common user cleanup locations. It does not imply automatic deletion. Callers should present the category, explanation, risk, and recommendation so users can decide what to inspect or clean manually.
 
@@ -63,8 +63,11 @@ interface ScanProgress {
   pathsScanned: number;
   directoriesScanned: number;
   filesScanned: number;
+  logicalSizeScanned: number;
   currentPath: string | null;
 }
 ```
+
+Callers may pass repeated `--exclude <path>` arguments. Excluded subtrees are not traversed, and the scanner reports each skipped subtree as a `skipped` warning diagnostic so UI and CLI callers can make scan incompleteness explicit.
 
 TypeScript callers should use `runScan()` from `@zpace/scanner/src/run` to consume these events as a `ScanLifecycleSnapshot` and to cancel active scans via the spawned Zig process.

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "test": "turbo test",
     "scan": "bun run packages/scanner/src/cli.ts",
     "dev:web": "turbo -F web dev",
-    "dev:desktop": "turbo -F desktop dev:hmr",
-    "build:desktop": "turbo -F desktop build:stable",
-    "build:desktop:canary": "turbo -F desktop build:canary"
+    "dev:desktop": "bun --filter desktop dev:hmr",
+    "build:desktop": "bun --filter desktop build:stable",
+    "build:desktop:canary": "bun --filter desktop build:canary"
   },
   "dependencies": {
     "@zpace/env": "workspace:*",

--- a/packages/scanner/native/src/aggregate_cache.zig
+++ b/packages/scanner/native/src/aggregate_cache.zig
@@ -1,0 +1,188 @@
+const std = @import("std");
+
+const report = @import("report.zig");
+const scan_policy = @import("scan_policy.zig");
+
+pub const DirectoryAggregate = struct {
+    logical_size: u64 = 0,
+    file_count: u64 = 0,
+    directory_count: u64 = 0,
+    child_count: u64 = 0,
+    status: report.ScanStatus = .complete,
+};
+
+pub const MemoryCache = std.StringHashMapUnmanaged(DirectoryAggregate);
+
+const PersistentAggregate = struct {
+    inode: u64,
+    mtime: i96,
+    size: u64,
+    aggregate: DirectoryAggregate,
+};
+
+pub const PersistentCache = std.StringHashMapUnmanaged(PersistentAggregate);
+
+pub fn reusableKey(allocator: std.mem.Allocator, path: []const u8) !?[]const u8 {
+    return try scan_policy.createReusableAggregateKey(allocator, path);
+}
+
+pub fn getMemory(
+    cache: *MemoryCache,
+    key: []const u8,
+) ?DirectoryAggregate {
+    return cache.get(key);
+}
+
+pub fn putMemoryComplete(
+    allocator: std.mem.Allocator,
+    cache: *MemoryCache,
+    cache_key: ?[]const u8,
+    aggregate: DirectoryAggregate,
+) !void {
+    if (cache_key) |key| {
+        if (aggregate.status == .complete) {
+            try cache.put(allocator, try allocator.dupe(u8, key), aggregate);
+        }
+    }
+}
+
+pub fn getPersistent(
+    persistent_cache: *PersistentCache,
+    key: []const u8,
+    stat: std.Io.File.Stat,
+) ?DirectoryAggregate {
+    const cached = persistent_cache.get(key) orelse return null;
+    if (cached.inode != stat.inode) return null;
+    if (cached.mtime != stat.mtime.nanoseconds) return null;
+    if (cached.size != stat.size) return null;
+    return cached.aggregate;
+}
+
+pub fn putPersistentComplete(
+    allocator: std.mem.Allocator,
+    persistent_cache: *PersistentCache,
+    key: []const u8,
+    stat: std.Io.File.Stat,
+    aggregate: DirectoryAggregate,
+) !void {
+    if (aggregate.status != .complete) return;
+
+    const entry = try persistent_cache.getOrPut(allocator, key);
+    if (!entry.found_existing) {
+        entry.key_ptr.* = try allocator.dupe(u8, key);
+    }
+    entry.value_ptr.* = .{
+        .inode = stat.inode,
+        .mtime = stat.mtime.nanoseconds,
+        .size = stat.size,
+        .aggregate = aggregate,
+    };
+}
+
+pub fn load(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    path: []const u8,
+    persistent_cache: *PersistentCache,
+) !void {
+    const data = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(16 * 1024 * 1024)) catch return;
+    defer allocator.free(data);
+
+    var lines = std.mem.splitScalar(u8, data, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        var fields = std.mem.splitScalar(u8, line, '\t');
+        const key = fields.next() orelse continue;
+        const inode_text = fields.next() orelse continue;
+        const mtime_text = fields.next() orelse continue;
+        const size_text = fields.next() orelse continue;
+        const logical_size_text = fields.next() orelse continue;
+        const file_count_text = fields.next() orelse continue;
+        const directory_count_text = fields.next() orelse continue;
+        const child_count_text = fields.next() orelse continue;
+
+        const inode = std.fmt.parseInt(u64, inode_text, 10) catch continue;
+        const mtime = std.fmt.parseInt(i96, mtime_text, 10) catch continue;
+        const size = std.fmt.parseInt(u64, size_text, 10) catch continue;
+        const logical_size = std.fmt.parseInt(u64, logical_size_text, 10) catch continue;
+        const file_count = std.fmt.parseInt(u64, file_count_text, 10) catch continue;
+        const directory_count = std.fmt.parseInt(u64, directory_count_text, 10) catch continue;
+        const child_count = std.fmt.parseInt(u64, child_count_text, 10) catch continue;
+
+        try persistent_cache.put(allocator, try allocator.dupe(u8, key), .{
+            .inode = inode,
+            .mtime = mtime,
+            .size = size,
+            .aggregate = .{
+                .logical_size = logical_size,
+                .file_count = file_count,
+                .directory_count = directory_count,
+                .child_count = child_count,
+                .status = .complete,
+            },
+        });
+    }
+}
+
+pub fn save(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    path: []const u8,
+    persistent_cache: *PersistentCache,
+) !void {
+    var data: std.ArrayListUnmanaged(u8) = .empty;
+    defer data.deinit(allocator);
+
+    var iterator = persistent_cache.iterator();
+    while (iterator.next()) |entry| {
+        const line = try std.fmt.allocPrint(
+            allocator,
+            "{s}\t{d}\t{d}\t{d}\t{d}\t{d}\t{d}\t{d}\n",
+            .{
+                entry.key_ptr.*,
+                entry.value_ptr.inode,
+                entry.value_ptr.mtime,
+                entry.value_ptr.size,
+                entry.value_ptr.aggregate.logical_size,
+                entry.value_ptr.aggregate.file_count,
+                entry.value_ptr.aggregate.directory_count,
+                entry.value_ptr.aggregate.child_count,
+            },
+        );
+        defer allocator.free(line);
+        try data.appendSlice(allocator, line);
+    }
+
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = data.items });
+}
+
+pub fn freeMemory(allocator: std.mem.Allocator, cache: *MemoryCache) void {
+    var iterator = cache.iterator();
+    while (iterator.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+    }
+    cache.deinit(allocator);
+}
+
+pub fn freePersistent(allocator: std.mem.Allocator, persistent_cache: *PersistentCache) void {
+    var iterator = persistent_cache.iterator();
+    while (iterator.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+    }
+    persistent_cache.deinit(allocator);
+}
+
+
+test "creates reusable aggregate identities for nested package stores" {
+    const allocator = std.testing.allocator;
+
+    const pnpm_key = (try reusableKey(allocator, "/tmp/app/node_modules/.pnpm/react@1.0.0")) orelse return error.ExpectedKey;
+    defer allocator.free(pnpm_key);
+    try std.testing.expectEqualStrings("pnpm:react@1.0.0", pnpm_key);
+
+    const bun_key = (try reusableKey(allocator, "/tmp/app/node_modules/.bun/react")) orelse return error.ExpectedKey;
+    defer allocator.free(bun_key);
+    try std.testing.expectEqualStrings("bun:react", bun_key);
+
+    try std.testing.expectEqual(@as(?[]const u8, null), try reusableKey(allocator, "/tmp/app/vendor/react"));
+}

--- a/packages/scanner/native/src/events.zig
+++ b/packages/scanner/native/src/events.zig
@@ -1,30 +1,33 @@
-const report = @import("report.zig");
+const report_json = @import("report_json.zig");
 
 pub const ScanProgress = struct {
     paths_scanned: u64 = 0,
     directories_scanned: u64 = 0,
     files_scanned: u64 = 0,
+    logical_size_scanned: u64 = 0,
     current_path: ?[]const u8 = null,
 };
 
 pub fn writeStartedEvent(writer: anytype, path: []const u8) !void {
     try writer.writeAll("{\"type\":\"started\",\"path\":");
-    try report.writeJsonString(writer, path);
+    try report_json.writeJsonString(writer, path);
     try writer.writeAll("}\n");
 }
 
 pub fn writeProgressEvent(writer: anytype, event_type: []const u8, progress: ScanProgress) !void {
     try writer.writeAll("{\"type\":");
-    try report.writeJsonString(writer, event_type);
+    try report_json.writeJsonString(writer, event_type);
     try writer.writeAll(",\"progress\":{\"pathsScanned\":");
     try writer.print("{}", .{progress.paths_scanned});
     try writer.writeAll(",\"directoriesScanned\":");
     try writer.print("{}", .{progress.directories_scanned});
     try writer.writeAll(",\"filesScanned\":");
     try writer.print("{}", .{progress.files_scanned});
+    try writer.writeAll(",\"logicalSizeScanned\":");
+    try writer.print("{}", .{progress.logical_size_scanned});
     try writer.writeAll(",\"currentPath\":");
     if (progress.current_path) |current_path| {
-        try report.writeJsonString(writer, current_path);
+        try report_json.writeJsonString(writer, current_path);
     } else {
         try writer.writeAll("null");
     }

--- a/packages/scanner/native/src/main.zig
+++ b/packages/scanner/native/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const events = @import("events.zig");
 const report = @import("report.zig");
+const report_json = @import("report_json.zig");
 const scanner = @import("scanner.zig");
 
 pub fn main(init: std.process.Init) !void {
@@ -12,32 +13,53 @@ pub fn main(init: std.process.Init) !void {
     _ = args.skip();
 
     var emit_events = false;
+    var deep_scan_generated = false;
     var input_path: ?[]const u8 = null;
+    var exclude_args: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer exclude_args.deinit(allocator);
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--events")) {
             emit_events = true;
+        } else if (std.mem.eql(u8, arg, "--deep-scan")) {
+            deep_scan_generated = true;
+        } else if (std.mem.eql(u8, arg, "--exclude")) {
+            const exclude_path = args.next() orelse {
+                std.debug.print("usage: zpace-scanner [--events] [--deep-scan] [--exclude <path>] <path>\n", .{});
+                std.process.exit(64);
+            };
+            try exclude_args.append(allocator, exclude_path);
         } else {
             input_path = arg;
         }
     }
 
     const requested_path = input_path orelse {
-        std.debug.print("usage: zpace-scanner <path>\n", .{});
+        std.debug.print("usage: zpace-scanner [--events] [--deep-scan] [--exclude <path>] <path>\n", .{});
         std.process.exit(64);
     };
-    const absolute_path = if (std.fs.path.isAbsolute(requested_path))
-        try allocator.dupe(u8, requested_path)
-    else blk: {
-        const cwd_path = try std.process.currentPathAlloc(init.io, allocator);
-        defer allocator.free(cwd_path);
-        break :blk try std.fs.path.join(allocator, &.{ cwd_path, requested_path });
-    };
+    const absolute_path = try absolutePath(allocator, init.io, requested_path);
     defer allocator.free(absolute_path);
+
+    var exclude_paths: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer {
+        for (exclude_paths.items) |exclude_path| allocator.free(exclude_path);
+        exclude_paths.deinit(allocator);
+    }
+    for (exclude_args.items) |exclude_arg| {
+        try exclude_paths.append(allocator, try absolutePath(allocator, init.io, exclude_arg));
+    }
+    const aggregate_cache_path = try defaultAggregateCachePath(allocator, init.io, init.environ_map);
+    defer if (aggregate_cache_path) |path| allocator.free(path);
 
     var stderr_buffer: [4096]u8 = undefined;
     var stderr_file_writer = std.Io.File.stderr().writerStreaming(init.io, &stderr_buffer);
     const stderr = &stderr_file_writer.interface;
-    const options = scanner.ScanOptions{ .emit_events = emit_events };
+    const options = scanner.ScanOptions{
+        .emit_events = emit_events,
+        .exclude_paths = exclude_paths.items,
+        .aggregate_cache_path = aggregate_cache_path,
+        .deep_scan_generated = deep_scan_generated,
+    };
     var progress = events.ScanProgress{};
     if (options.emit_events) {
         try events.writeStartedEvent(stderr, absolute_path);
@@ -55,6 +77,36 @@ pub fn main(init: std.process.Init) !void {
     var stdout_buffer: [4096]u8 = undefined;
     var stdout_file_writer = std.Io.File.stdout().writerStreaming(init.io, &stdout_buffer);
     const stdout = &stdout_file_writer.interface;
-    try report.writeReport(stdout, scan_report);
+    try report_json.writeReport(stdout, scan_report);
     try stdout.flush();
+}
+
+fn absolutePath(allocator: std.mem.Allocator, io: std.Io, path: []const u8) ![]const u8 {
+    if (std.fs.path.isAbsolute(path)) return try allocator.dupe(u8, path);
+
+    const cwd_path = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(cwd_path);
+    return try std.fs.path.join(allocator, &.{ cwd_path, path });
+}
+
+fn defaultAggregateCachePath(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    environ_map: *std.process.Environ.Map,
+) !?[]const u8 {
+    if (environ_map.get("XDG_CACHE_HOME")) |cache_home| {
+        const cache_dir = try std.fs.path.join(allocator, &.{ cache_home, "zpace" });
+        defer allocator.free(cache_dir);
+        std.Io.Dir.cwd().createDirPath(io, cache_dir) catch {};
+        return try std.fs.path.join(allocator, &.{ cache_dir, "scanner-aggregates.tsv" });
+    }
+
+    if (environ_map.get("HOME")) |home| {
+        const library_cache_dir = try std.fs.path.join(allocator, &.{ home, "Library", "Caches", "zpace" });
+        defer allocator.free(library_cache_dir);
+        std.Io.Dir.cwd().createDirPath(io, library_cache_dir) catch {};
+        return try std.fs.path.join(allocator, &.{ library_cache_dir, "scanner-aggregates.tsv" });
+    }
+
+    return null;
 }

--- a/packages/scanner/native/src/main_test.zig
+++ b/packages/scanner/native/src/main_test.zig
@@ -1,11 +1,19 @@
 const std = @import("std");
 
+const aggregate_cache = @import("aggregate_cache.zig");
 const events = @import("events.zig");
 const classification = @import("classification.zig");
+const report_builder = @import("report_builder.zig");
+const report_json = @import("report_json.zig");
+const scan_policy = @import("scan_policy.zig");
 const scanner = @import("scanner.zig");
 
 test {
+    _ = aggregate_cache;
     _ = classification;
+    _ = report_builder;
+    _ = report_json;
+    _ = scan_policy;
 }
 
 test "scanner defaults start with no events and empty progress" {
@@ -13,6 +21,10 @@ test "scanner defaults start with no events and empty progress" {
     const progress = events.ScanProgress{};
 
     try std.testing.expect(!options.emit_events);
+    try std.testing.expectEqual(@as(usize, 64), options.max_children_per_directory);
+    try std.testing.expectEqual(@as(usize, 4), options.max_aggregate_workers);
+    try std.testing.expectEqual(@as(usize, 0), options.exclude_paths.len);
+    try std.testing.expect(!options.deep_scan_generated);
     try std.testing.expectEqual(@as(u64, 0), progress.paths_scanned);
     try std.testing.expectEqual(@as(?[]const u8, null), progress.current_path);
 }

--- a/packages/scanner/native/src/report.zig
+++ b/packages/scanner/native/src/report.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const classification = @import("classification.zig");
+const scan_policy = @import("scan_policy.zig");
 
 pub const ItemType = enum { file, directory, symlink, other };
 pub const ScanStatus = enum { complete, partial, failed };
@@ -22,8 +22,9 @@ pub const Node = struct {
     logical_size: u64,
     allocated_size: ?u64,
     child_count: u64,
+    omitted_child_count: u64,
     status: ScanStatus,
-    classification: ?classification.Classification,
+    classification: ?scan_policy.Classification,
     children: std.ArrayListUnmanaged(Node),
 };
 
@@ -32,7 +33,7 @@ pub const SummaryItem = struct {
     name: []const u8,
     item_type: ItemType,
     logical_size: u64,
-    classification: ?classification.Classification,
+    classification: ?scan_policy.Classification,
 };
 
 pub const CategorySummary = struct {
@@ -66,8 +67,7 @@ pub const ScanReport = struct {
 };
 
 pub fn freeReport(allocator: std.mem.Allocator, scan_report: *ScanReport) void {
-    scan_report.summary.largest_items.deinit(allocator);
-    scan_report.summary.categories.deinit(allocator);
+    freeSummary(allocator, &scan_report.summary);
     freeNode(allocator, &scan_report.root);
     for (scan_report.diagnostics.items) |diagnostic| {
         allocator.free(diagnostic.path);
@@ -77,44 +77,12 @@ pub fn freeReport(allocator: std.mem.Allocator, scan_report: *ScanReport) void {
     scan_report.diagnostics.deinit(allocator);
 }
 
-pub fn buildSummary(
-    allocator: std.mem.Allocator,
-    root: *const Node,
-    diagnostics: []const Diagnostic,
-    duration_ms: u64,
-) !ScanSummary {
-    var summary = ScanSummary{
-        .total_logical_size = root.logical_size,
-        .total_allocated_size = null,
-        .likely_reclaimable_size = 0,
-        .file_count = 0,
-        .folder_count = 0,
-        .warning_count = 0,
-        .inaccessible_count = 0,
-        .skipped_count = 0,
-        .protected_count = 0,
-        .free_size = null,
-        .purgeable_size = null,
-        .duration_ms = duration_ms,
-        .largest_items = .empty,
-        .categories = .empty,
-    };
-    errdefer summary.largest_items.deinit(allocator);
-    errdefer summary.categories.deinit(allocator);
-
-    for (diagnostics) |diagnostic| {
-        if (diagnostic.severity == .warning) summary.warning_count += 1;
-        if (diagnostic.kind == .inaccessible) summary.inaccessible_count += 1;
-        if (diagnostic.kind == .skipped) summary.skipped_count += 1;
+pub fn freeSummary(allocator: std.mem.Allocator, summary: *ScanSummary) void {
+    for (summary.largest_items.items) |*item| {
+        freeSummaryItem(allocator, item);
     }
-
-    try collectSummary(allocator, &summary, root, true);
-    std.mem.sort(SummaryItem, summary.largest_items.items, {}, largerSummaryItem);
-    if (summary.largest_items.items.len > 10) {
-        summary.largest_items.shrinkRetainingCapacity(10);
-    }
-
-    return summary;
+    summary.largest_items.deinit(allocator);
+    summary.categories.deinit(allocator);
 }
 
 pub fn freeNode(allocator: std.mem.Allocator, node: *Node) void {
@@ -126,253 +94,7 @@ pub fn freeNode(allocator: std.mem.Allocator, node: *Node) void {
     allocator.free(node.name);
 }
 
-pub fn writeReport(writer: anytype, scan_report: ScanReport) !void {
-    try writer.writeAll("{\"schemaVersion\":1,\"root\":");
-    try writeNode(writer, scan_report.root);
-    try writer.writeAll(",\"summary\":");
-    try writeSummary(writer, scan_report.summary);
-    try writer.writeAll(",\"diagnostics\":[");
-    for (scan_report.diagnostics.items, 0..) |diagnostic, index| {
-        if (index > 0) try writer.writeByte(',');
-        try writeDiagnostic(writer, diagnostic);
-    }
-    try writer.writeAll("]}\n");
-}
-
-fn collectSummary(
-    allocator: std.mem.Allocator,
-    summary: *ScanSummary,
-    node: *const Node,
-    is_root: bool,
-) !void {
-    if (node.item_type == .file) summary.file_count += 1;
-    if (node.item_type == .directory) summary.folder_count += 1;
-    if (node.allocated_size) |size| {
-        summary.total_allocated_size = (summary.total_allocated_size orelse 0) + size;
-    }
-
-    if (!is_root) {
-        try summary.largest_items.append(allocator, .{
-            .path = node.path,
-            .name = node.name,
-            .item_type = node.item_type,
-            .logical_size = node.logical_size,
-            .classification = node.classification,
-        });
-    }
-
-    if (node.classification) |node_classification| {
-        if (node_classification.is_protected) summary.protected_count += 1;
-        const reclaimable_size = if (node_classification.risk == .low) node.logical_size else 0;
-        summary.likely_reclaimable_size += reclaimable_size;
-        try addCategorySize(
-            allocator,
-            &summary.categories,
-            node_classification.category,
-            node.logical_size,
-            reclaimable_size,
-        );
-    }
-
-    for (node.children.items) |*child| {
-        try collectSummary(allocator, summary, child, false);
-    }
-}
-
-fn addCategorySize(
-    allocator: std.mem.Allocator,
-    categories: *std.ArrayListUnmanaged(CategorySummary),
-    category: []const u8,
-    logical_size: u64,
-    reclaimable_size: u64,
-) !void {
-    for (categories.items) |*item| {
-        if (std.mem.eql(u8, item.category, category)) {
-            item.logical_size += logical_size;
-            item.item_count += 1;
-            item.likely_reclaimable_size += reclaimable_size;
-            return;
-        }
-    }
-
-    try categories.append(allocator, .{
-        .category = category,
-        .logical_size = logical_size,
-        .item_count = 1,
-        .likely_reclaimable_size = reclaimable_size,
-    });
-}
-
-fn largerSummaryItem(_: void, left: SummaryItem, right: SummaryItem) bool {
-    if (left.logical_size == right.logical_size) {
-        return std.mem.lessThan(u8, left.name, right.name);
-    }
-    return left.logical_size > right.logical_size;
-}
-
-fn writeSummary(writer: anytype, summary: ScanSummary) !void {
-    try writer.print(
-        "{{\"totalLogicalSize\":{},\"totalAllocatedSize\":",
-        .{summary.total_logical_size},
-    );
-    if (summary.total_allocated_size) |size| {
-        try writer.print("{}", .{size});
-    } else {
-        try writer.writeAll("null");
-    }
-    try writer.print(
-        ",\"likelyReclaimableSize\":{},\"fileCount\":{},\"folderCount\":{},\"warningCount\":{},\"inaccessibleCount\":{},\"skippedCount\":{},\"protectedCount\":{},\"freeSize\":",
-        .{
-            summary.likely_reclaimable_size,
-            summary.file_count,
-            summary.folder_count,
-            summary.warning_count,
-            summary.inaccessible_count,
-            summary.skipped_count,
-            summary.protected_count,
-        },
-    );
-    if (summary.free_size) |size| {
-        try writer.print("{}", .{size});
-    } else {
-        try writer.writeAll("null");
-    }
-    try writer.writeAll(",\"purgeableSize\":");
-    if (summary.purgeable_size) |size| {
-        try writer.print("{}", .{size});
-    } else {
-        try writer.writeAll("null");
-    }
-    try writer.print(",\"durationMs\":{},\"largestItems\":[", .{summary.duration_ms});
-    for (summary.largest_items.items, 0..) |item, index| {
-        if (index > 0) try writer.writeByte(',');
-        try writeSummaryItem(writer, item);
-    }
-    try writer.writeAll("],\"categories\":[");
-    for (summary.categories.items, 0..) |category, index| {
-        if (index > 0) try writer.writeByte(',');
-        try writeCategorySummary(writer, category);
-    }
-    try writer.writeAll("]}");
-}
-
-fn writeSummaryItem(writer: anytype, item: SummaryItem) !void {
-    try writer.writeAll("{\"path\":");
-    try writeJsonString(writer, item.path);
-    try writer.writeAll(",\"name\":");
-    try writeJsonString(writer, item.name);
-    try writer.writeAll(",\"type\":");
-    try writeJsonString(writer, @tagName(item.item_type));
-    try writer.print(",\"logicalSize\":{},\"classification\":", .{item.logical_size});
-    if (item.classification) |item_classification| {
-        try writeClassification(writer, item_classification);
-    } else {
-        try writer.writeAll("null");
-    }
-    try writer.writeAll("}");
-}
-
-fn writeCategorySummary(writer: anytype, category: CategorySummary) !void {
-    try writer.writeAll("{\"category\":");
-    try writeJsonString(writer, category.category);
-    try writer.print(
-        ",\"logicalSize\":{},\"itemCount\":{},\"likelyReclaimableSize\":{}",
-        .{ category.logical_size, category.item_count, category.likely_reclaimable_size },
-    );
-    try writer.writeAll("}");
-}
-
-fn writeNode(writer: anytype, node: Node) !void {
-    try writer.writeAll("{\"path\":");
-    try writeJsonString(writer, node.path);
-    try writer.writeAll(",\"name\":");
-    try writeJsonString(writer, node.name);
-    try writer.writeAll(",\"type\":");
-    try writeJsonString(writer, @tagName(node.item_type));
-    try writer.print(",\"logicalSize\":{},\"allocatedSize\":", .{node.logical_size});
-    if (node.allocated_size) |size| {
-        try writer.print("{}", .{size});
-    } else {
-        try writer.writeAll("null");
-    }
-    try writer.print(",\"childCount\":{},\"status\":", .{node.child_count});
-    try writeJsonString(writer, statusName(node.status));
-    try writer.writeAll(",\"classification\":");
-    if (node.classification) |node_classification| {
-        try writeClassification(writer, node_classification);
-    } else {
-        try writer.writeAll("null");
-    }
-    try writer.writeAll(",\"children\":[");
-    for (node.children.items, 0..) |child, index| {
-        if (index > 0) try writer.writeByte(',');
-        try writeNode(writer, child);
-    }
-    try writer.writeAll("]}");
-}
-
-fn writeClassification(writer: anytype, node_classification: classification.Classification) !void {
-    try writer.writeAll("{\"category\":");
-    try writeJsonString(writer, node_classification.category);
-    try writer.writeAll(",\"explanation\":");
-    try writeJsonString(writer, node_classification.explanation);
-    try writer.writeAll(",\"risk\":");
-    try writeJsonString(writer, @tagName(node_classification.risk));
-    try writer.writeAll(",\"recommendation\":");
-    try writeJsonString(writer, node_classification.recommendation);
-    try writer.print(",\"isProtected\":{}", .{node_classification.is_protected});
-    try writer.writeAll(",\"protectionReason\":");
-    if (node_classification.protection_reason) |reason| {
-        try writeJsonString(writer, reason);
-    } else {
-        try writer.writeAll("null");
-    }
-    try writer.writeAll("}");
-}
-
-fn writeDiagnostic(writer: anytype, diagnostic: Diagnostic) !void {
-    try writer.writeAll("{\"path\":");
-    try writeJsonString(writer, diagnostic.path);
-    try writer.writeAll(",\"kind\":");
-    try writeJsonString(writer, @tagName(diagnostic.kind));
-    try writer.writeAll(",\"severity\":");
-    try writeJsonString(writer, @tagName(diagnostic.severity));
-    try writer.writeAll(",\"message\":");
-    try writeJsonString(writer, diagnostic.message);
-    try writer.writeAll(",\"guidance\":");
-    if (diagnostic.guidance) |guidance| {
-        try writeJsonString(writer, guidance);
-    } else {
-        try writer.writeAll("null");
-    }
-    try writer.writeAll("}");
-}
-
-pub fn writeJsonString(writer: anytype, value: []const u8) !void {
-    try writer.writeByte('"');
-    for (value) |char| {
-        switch (char) {
-            '"' => try writer.writeAll("\\\""),
-            '\\' => try writer.writeAll("\\\\"),
-            '\n' => try writer.writeAll("\\n"),
-            '\r' => try writer.writeAll("\\r"),
-            '\t' => try writer.writeAll("\\t"),
-            else => {
-                if (char < 0x20) {
-                    try writer.print("\\u{x:0>4}", .{char});
-                } else {
-                    try writer.writeByte(char);
-                }
-            },
-        }
-    }
-    try writer.writeByte('"');
-}
-
-fn statusName(status: ScanStatus) []const u8 {
-    return switch (status) {
-        .complete => "complete",
-        .partial => "partial",
-        .failed => "error",
-    };
+fn freeSummaryItem(allocator: std.mem.Allocator, item: *SummaryItem) void {
+    allocator.free(item.path);
+    allocator.free(item.name);
 }

--- a/packages/scanner/native/src/report_builder.zig
+++ b/packages/scanner/native/src/report_builder.zig
@@ -1,0 +1,237 @@
+const std = @import("std");
+
+const report = @import("report.zig");
+const scan_policy = @import("scan_policy.zig");
+
+pub fn initSummary() report.ScanSummary {
+    return .{
+        .total_logical_size = 0,
+        .total_allocated_size = null,
+        .likely_reclaimable_size = 0,
+        .file_count = 0,
+        .folder_count = 0,
+        .warning_count = 0,
+        .inaccessible_count = 0,
+        .skipped_count = 0,
+        .protected_count = 0,
+        .free_size = null,
+        .purgeable_size = null,
+        .duration_ms = 0,
+        .largest_items = .empty,
+        .categories = .empty,
+    };
+}
+
+pub fn observeDiagnostic(summary: *report.ScanSummary, diagnostic: report.Diagnostic) void {
+    if (diagnostic.severity == .warning) summary.warning_count += 1;
+    if (diagnostic.kind == .inaccessible) summary.inaccessible_count += 1;
+    if (diagnostic.kind == .skipped) summary.skipped_count += 1;
+}
+
+pub fn observeNode(
+    allocator: std.mem.Allocator,
+    summary: *report.ScanSummary,
+    node: *const report.Node,
+    is_root: bool,
+) !void {
+    if (node.item_type == .file) {
+        summary.file_count += 1;
+        summary.total_logical_size += node.logical_size;
+    }
+    if (node.item_type == .directory) summary.folder_count += 1;
+    if (node.allocated_size) |size| {
+        summary.total_allocated_size = (summary.total_allocated_size orelse 0) + size;
+    }
+
+    try observeClassifiedItem(allocator, summary, node, is_root);
+}
+
+pub fn observeSummarizedDirectory(
+    allocator: std.mem.Allocator,
+    summary: *report.ScanSummary,
+    node: *const report.Node,
+    is_root: bool,
+    descendant_file_count: u64,
+    descendant_directory_count: u64,
+) !void {
+    summary.file_count += descendant_file_count;
+    summary.folder_count += 1 + descendant_directory_count;
+    summary.total_logical_size += node.logical_size;
+
+    try observeClassifiedItem(allocator, summary, node, is_root);
+}
+
+pub fn buildSummary(
+    allocator: std.mem.Allocator,
+    root: *const report.Node,
+    diagnostics: []const report.Diagnostic,
+    duration_ms: u64,
+) !report.ScanSummary {
+    var summary = initSummary();
+    errdefer report.freeSummary(allocator, &summary);
+    summary.duration_ms = duration_ms;
+
+    for (diagnostics) |diagnostic| {
+        observeDiagnostic(&summary, diagnostic);
+    }
+
+    try collectSummary(allocator, &summary, root, true);
+    return summary;
+}
+
+pub fn boundNodeChildren(allocator: std.mem.Allocator, node: *report.Node, max_children: usize) void {
+    for (node.children.items) |*child| {
+        boundNodeChildren(allocator, child, max_children);
+    }
+
+    retainTopChildren(allocator, node, max_children);
+}
+
+pub fn retainTopChildren(allocator: std.mem.Allocator, node: *report.Node, max_children: usize) void {
+    std.mem.sort(report.Node, node.children.items, {}, largerNode);
+    if (node.children.items.len <= max_children) {
+        node.omitted_child_count = 0;
+        return;
+    }
+
+    const retained_len = max_children;
+    for (node.children.items[retained_len..]) |*child| {
+        report.freeNode(allocator, child);
+    }
+    node.children.shrinkRetainingCapacity(retained_len);
+    node.omitted_child_count = node.child_count - retained_len;
+}
+
+fn observeClassifiedItem(
+    allocator: std.mem.Allocator,
+    summary: *report.ScanSummary,
+    node: *const report.Node,
+    is_root: bool,
+) !void {
+    if (!is_root) {
+        try appendLargestItem(allocator, summary, node);
+    }
+
+    if (node.classification) |node_classification| {
+        if (scan_policy.isProtected(node.classification)) summary.protected_count += 1;
+        const reclaimable_size = if (scan_policy.risk(node.classification) == .low) node.logical_size else 0;
+        summary.likely_reclaimable_size += reclaimable_size;
+        try addCategorySize(
+            allocator,
+            &summary.categories,
+            node_classification.category,
+            node.logical_size,
+            reclaimable_size,
+        );
+    }
+}
+
+fn collectSummary(
+    allocator: std.mem.Allocator,
+    summary: *report.ScanSummary,
+    node: *const report.Node,
+    is_root: bool,
+) !void {
+    try observeNode(allocator, summary, node, is_root);
+
+    for (node.children.items) |*child| {
+        try collectSummary(allocator, summary, child, false);
+    }
+}
+
+fn appendLargestItem(
+    allocator: std.mem.Allocator,
+    summary: *report.ScanSummary,
+    node: *const report.Node,
+) !void {
+    const path_copy = try allocator.dupe(u8, node.path);
+    errdefer allocator.free(path_copy);
+    const name_copy = try allocator.dupe(u8, node.name);
+    errdefer allocator.free(name_copy);
+
+    try summary.largest_items.append(allocator, .{
+        .path = path_copy,
+        .name = name_copy,
+        .item_type = node.item_type,
+        .logical_size = node.logical_size,
+        .classification = node.classification,
+    });
+
+    std.mem.sort(report.SummaryItem, summary.largest_items.items, {}, largerSummaryItem);
+    if (summary.largest_items.items.len > 10) {
+        freeSummaryItem(allocator, &summary.largest_items.items[10]);
+        summary.largest_items.shrinkRetainingCapacity(10);
+    }
+}
+
+fn freeSummaryItem(allocator: std.mem.Allocator, item: *report.SummaryItem) void {
+    allocator.free(item.path);
+    allocator.free(item.name);
+}
+
+fn addCategorySize(
+    allocator: std.mem.Allocator,
+    categories: *std.ArrayListUnmanaged(report.CategorySummary),
+    category: []const u8,
+    logical_size: u64,
+    reclaimable_size: u64,
+) !void {
+    for (categories.items) |*item| {
+        if (std.mem.eql(u8, item.category, category)) {
+            item.logical_size += logical_size;
+            item.item_count += 1;
+            item.likely_reclaimable_size += reclaimable_size;
+            return;
+        }
+    }
+
+    try categories.append(allocator, .{
+        .category = category,
+        .logical_size = logical_size,
+        .item_count = 1,
+        .likely_reclaimable_size = reclaimable_size,
+    });
+}
+
+fn largerNode(_: void, left: report.Node, right: report.Node) bool {
+    if (left.logical_size == right.logical_size) {
+        return std.mem.lessThan(u8, left.name, right.name);
+    }
+    return left.logical_size > right.logical_size;
+}
+
+fn largerSummaryItem(_: void, left: report.SummaryItem, right: report.SummaryItem) bool {
+    if (left.logical_size == right.logical_size) {
+        return std.mem.lessThan(u8, left.name, right.name);
+    }
+    return left.logical_size > right.logical_size;
+}
+
+test "aggregates node totals and category summaries" {
+    const allocator = std.testing.allocator;
+    var summary = initSummary();
+    defer report.freeSummary(allocator, &summary);
+
+    const node = report.Node{
+        .path = "/tmp/app/node_modules",
+        .name = "node_modules",
+        .item_type = .directory,
+        .logical_size = 42,
+        .allocated_size = null,
+        .child_count = 0,
+        .omitted_child_count = 0,
+        .status = .complete,
+        .classification = scan_policy.classify("/tmp/app/node_modules", "node_modules"),
+        .children = .empty,
+    };
+
+    try observeSummarizedDirectory(allocator, &summary, &node, false, 3, 1);
+
+    try std.testing.expectEqual(@as(u64, 42), summary.total_logical_size);
+    try std.testing.expectEqual(@as(u64, 3), summary.file_count);
+    try std.testing.expectEqual(@as(u64, 2), summary.folder_count);
+    try std.testing.expectEqual(@as(usize, 1), summary.largest_items.items.len);
+    try std.testing.expectEqual(@as(usize, 1), summary.categories.items.len);
+    try std.testing.expectEqualStrings("Developer artifacts", summary.categories.items[0].category);
+    try std.testing.expectEqual(@as(u64, 42), summary.categories.items[0].logical_size);
+}

--- a/packages/scanner/native/src/report_json.zig
+++ b/packages/scanner/native/src/report_json.zig
@@ -1,0 +1,196 @@
+const std = @import("std");
+
+const report = @import("report.zig");
+const scan_policy = @import("scan_policy.zig");
+
+pub fn writeReport(writer: anytype, scan_report: report.ScanReport) !void {
+    try writer.writeAll("{\"schemaVersion\":1,\"root\":");
+    try writeNode(writer, scan_report.root);
+    try writer.writeAll(",\"summary\":");
+    try writeSummary(writer, scan_report.summary);
+    try writer.writeAll(",\"diagnostics\":[");
+    for (scan_report.diagnostics.items, 0..) |diagnostic, index| {
+        if (index > 0) try writer.writeByte(',');
+        try writeDiagnostic(writer, diagnostic);
+    }
+    try writer.writeAll("]}\n");
+}
+
+fn writeSummary(writer: anytype, summary: report.ScanSummary) !void {
+    try writer.print(
+        "{{\"totalLogicalSize\":{},\"totalAllocatedSize\":",
+        .{summary.total_logical_size},
+    );
+    if (summary.total_allocated_size) |size| {
+        try writer.print("{}", .{size});
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.print(
+        ",\"likelyReclaimableSize\":{},\"fileCount\":{},\"folderCount\":{},\"warningCount\":{},\"inaccessibleCount\":{},\"skippedCount\":{},\"protectedCount\":{},\"freeSize\":",
+        .{
+            summary.likely_reclaimable_size,
+            summary.file_count,
+            summary.folder_count,
+            summary.warning_count,
+            summary.inaccessible_count,
+            summary.skipped_count,
+            summary.protected_count,
+        },
+    );
+    if (summary.free_size) |size| {
+        try writer.print("{}", .{size});
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"purgeableSize\":");
+    if (summary.purgeable_size) |size| {
+        try writer.print("{}", .{size});
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.print(",\"durationMs\":{},\"largestItems\":[", .{summary.duration_ms});
+    for (summary.largest_items.items, 0..) |item, index| {
+        if (index > 0) try writer.writeByte(',');
+        try writeSummaryItem(writer, item);
+    }
+    try writer.writeAll("],\"categories\":[");
+    for (summary.categories.items, 0..) |category, index| {
+        if (index > 0) try writer.writeByte(',');
+        try writeCategorySummary(writer, category);
+    }
+    try writer.writeAll("]}");
+}
+
+fn writeSummaryItem(writer: anytype, item: report.SummaryItem) !void {
+    try writer.writeAll("{\"path\":");
+    try writeJsonString(writer, item.path);
+    try writer.writeAll(",\"name\":");
+    try writeJsonString(writer, item.name);
+    try writer.writeAll(",\"type\":");
+    try writeJsonString(writer, @tagName(item.item_type));
+    try writer.print(",\"logicalSize\":{},\"classification\":", .{item.logical_size});
+    if (item.classification) |item_classification| {
+        try writeClassification(writer, item_classification);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll("}");
+}
+
+fn writeCategorySummary(writer: anytype, category: report.CategorySummary) !void {
+    try writer.writeAll("{\"category\":");
+    try writeJsonString(writer, category.category);
+    try writer.print(
+        ",\"logicalSize\":{},\"itemCount\":{},\"likelyReclaimableSize\":{}",
+        .{ category.logical_size, category.item_count, category.likely_reclaimable_size },
+    );
+    try writer.writeAll("}");
+}
+
+fn writeNode(writer: anytype, node: report.Node) !void {
+    try writer.writeAll("{\"path\":");
+    try writeJsonString(writer, node.path);
+    try writer.writeAll(",\"name\":");
+    try writeJsonString(writer, node.name);
+    try writer.writeAll(",\"type\":");
+    try writeJsonString(writer, @tagName(node.item_type));
+    try writer.print(",\"logicalSize\":{},\"allocatedSize\":", .{node.logical_size});
+    if (node.allocated_size) |size| {
+        try writer.print("{}", .{size});
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.print(
+        ",\"childCount\":{},\"omittedChildCount\":{},\"childrenTruncated\":{},\"status\":",
+        .{ node.child_count, node.omitted_child_count, node.omitted_child_count > 0 },
+    );
+    try writeJsonString(writer, statusName(node.status));
+    try writer.writeAll(",\"classification\":");
+    if (node.classification) |node_classification| {
+        try writeClassification(writer, node_classification);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"children\":[");
+    for (node.children.items, 0..) |child, index| {
+        if (index > 0) try writer.writeByte(',');
+        try writeNode(writer, child);
+    }
+    try writer.writeAll("]}");
+}
+
+fn writeClassification(writer: anytype, node_classification: scan_policy.Classification) !void {
+    try writer.writeAll("{\"category\":");
+    try writeJsonString(writer, node_classification.category);
+    try writer.writeAll(",\"explanation\":");
+    try writeJsonString(writer, node_classification.explanation);
+    try writer.writeAll(",\"risk\":");
+    try writeJsonString(writer, @tagName(node_classification.risk));
+    try writer.writeAll(",\"recommendation\":");
+    try writeJsonString(writer, node_classification.recommendation);
+    try writer.print(",\"isProtected\":{}", .{node_classification.is_protected});
+    try writer.writeAll(",\"protectionReason\":");
+    if (node_classification.protection_reason) |reason| {
+        try writeJsonString(writer, reason);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll("}");
+}
+
+fn writeDiagnostic(writer: anytype, diagnostic: report.Diagnostic) !void {
+    try writer.writeAll("{\"path\":");
+    try writeJsonString(writer, diagnostic.path);
+    try writer.writeAll(",\"kind\":");
+    try writeJsonString(writer, @tagName(diagnostic.kind));
+    try writer.writeAll(",\"severity\":");
+    try writeJsonString(writer, @tagName(diagnostic.severity));
+    try writer.writeAll(",\"message\":");
+    try writeJsonString(writer, diagnostic.message);
+    try writer.writeAll(",\"guidance\":");
+    if (diagnostic.guidance) |guidance| {
+        try writeJsonString(writer, guidance);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll("}");
+}
+
+pub fn writeJsonString(writer: anytype, value: []const u8) !void {
+    try writer.writeByte('"');
+    for (value) |char| {
+        switch (char) {
+            '"' => try writer.writeAll("\\\""),
+            '\\' => try writer.writeAll("\\\\"),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            else => {
+                if (char < 0x20) {
+                    try writer.print("\\u{x:0>4}", .{char});
+                } else {
+                    try writer.writeByte(char);
+                }
+            },
+        }
+    }
+    try writer.writeByte('"');
+}
+
+fn statusName(status: report.ScanStatus) []const u8 {
+    return switch (status) {
+        .complete => "complete",
+        .partial => "partial",
+        .failed => "error",
+    };
+}
+
+test "escapes JSON strings" {
+    var stream = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer stream.deinit();
+
+    try writeJsonString(&stream.writer, "a\"b\\c\n");
+
+    try std.testing.expectEqualStrings("\"a\\\"b\\\\c\\n\"", stream.written());
+}

--- a/packages/scanner/native/src/scan_policy.zig
+++ b/packages/scanner/native/src/scan_policy.zig
@@ -1,0 +1,96 @@
+const std = @import("std");
+
+const classification = @import("classification.zig");
+
+pub const Classification = classification.Classification;
+pub const RiskLevel = classification.RiskLevel;
+
+pub fn classify(path: []const u8, name: []const u8) ?Classification {
+    return classification.classify(path, name);
+}
+
+pub fn risk(classification_value: ?Classification) ?RiskLevel {
+    return if (classification_value) |value| value.risk else null;
+}
+
+pub fn isProtected(classification_value: ?Classification) bool {
+    return if (classification_value) |value| value.is_protected else false;
+}
+
+pub fn shouldSummarizeGeneratedDirectory(path: []const u8, name: []const u8, is_root: bool) bool {
+    if (is_root) return false;
+
+    return isProjectDependencyDirectory(name) or
+        equals(name, ".pnpm-store") or
+        equals(name, ".npm") or
+        equals(name, ".yarn") or
+        equals(name, ".bun") or
+        equals(name, ".venv") or
+        equals(name, "venv") or
+        contains(path, "/node_modules/") or
+        contains(path, "/.bun/install/cache") or
+        contains(path, "/.cargo/registry") or
+        contains(path, "/.cargo/git") or
+        contains(path, "/go/pkg/mod");
+}
+
+pub fn createReusableAggregateKey(allocator: std.mem.Allocator, path: []const u8) !?[]const u8 {
+    const parent = std.fs.path.dirname(path) orelse return null;
+    const parent_name = std.fs.path.basename(parent);
+    const grandparent = std.fs.path.dirname(parent) orelse return null;
+    const grandparent_name = std.fs.path.basename(grandparent);
+    if (!equals(grandparent_name, "node_modules")) return null;
+
+    if (equals(parent_name, ".bun")) return try prefixedKey(allocator, "bun:", std.fs.path.basename(path));
+    if (equals(parent_name, ".pnpm")) return try prefixedKey(allocator, "pnpm:", std.fs.path.basename(path));
+    return null;
+}
+
+fn isProjectDependencyDirectory(name: []const u8) bool {
+    return equals(name, "node_modules") or equals(name, "bower_components");
+}
+
+fn prefixedKey(allocator: std.mem.Allocator, prefix: []const u8, value: []const u8) ![]const u8 {
+    return try std.mem.concat(allocator, u8, &.{ prefix, value });
+}
+
+fn equals(left: []const u8, right: []const u8) bool {
+    return std.mem.eql(u8, left, right);
+}
+
+fn contains(haystack: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, haystack, needle) != null;
+}
+
+test "delegates classification and exposes risk/protection decisions" {
+    const protected_classification = classify("/System/Library/CoreServices", "CoreServices");
+    try std.testing.expect(isProtected(protected_classification));
+    try std.testing.expectEqual(RiskLevel.high, risk(protected_classification).?);
+
+    const generated_classification = classify("/tmp/app/.next", ".next");
+    try std.testing.expect(!isProtected(generated_classification));
+    try std.testing.expectEqual(RiskLevel.low, risk(generated_classification).?);
+}
+
+test "answers generated directory summary eligibility" {
+    try std.testing.expect(!shouldSummarizeGeneratedDirectory("/tmp/app/node_modules", "node_modules", true));
+    try std.testing.expect(!shouldSummarizeGeneratedDirectory("/tmp/app/.venv", ".venv", true));
+    try std.testing.expect(shouldSummarizeGeneratedDirectory("/tmp/app/node_modules", "node_modules", false));
+    try std.testing.expect(shouldSummarizeGeneratedDirectory("/tmp/app/node_modules/react", "react", false));
+    try std.testing.expect(shouldSummarizeGeneratedDirectory("/Users/me/.cargo/registry", "registry", false));
+    try std.testing.expect(!shouldSummarizeGeneratedDirectory("/Users/me/Documents", "Documents", false));
+}
+
+test "creates reusable aggregate identities for nested package stores" {
+    const allocator = std.testing.allocator;
+
+    const pnpm_key = (try createReusableAggregateKey(allocator, "/tmp/app/node_modules/.pnpm/react@1.0.0")) orelse return error.ExpectedKey;
+    defer allocator.free(pnpm_key);
+    try std.testing.expectEqualStrings("pnpm:react@1.0.0", pnpm_key);
+
+    const bun_key = (try createReusableAggregateKey(allocator, "/tmp/app/node_modules/.bun/react")) orelse return error.ExpectedKey;
+    defer allocator.free(bun_key);
+    try std.testing.expectEqualStrings("bun:react", bun_key);
+
+    try std.testing.expectEqual(@as(?[]const u8, null), try createReusableAggregateKey(allocator, "/tmp/app/vendor/react"));
+}

--- a/packages/scanner/native/src/scanner.zig
+++ b/packages/scanner/native/src/scanner.zig
@@ -1,14 +1,54 @@
 const std = @import("std");
 
+const aggregate_cache_module = @import("aggregate_cache.zig");
 const events = @import("events.zig");
-const classification = @import("classification.zig");
 const report = @import("report.zig");
+const report_builder = @import("report_builder.zig");
+const scan_policy = @import("scan_policy.zig");
 
 pub const ScanOptions = struct {
     emit_events: bool,
+    max_children_per_directory: usize = 64,
+    max_aggregate_workers: usize = 4,
+    exclude_paths: []const []const u8 = &.{},
+    aggregate_cache_path: ?[]const u8 = null,
+    deep_scan_generated: bool = false,
 };
 
-const progress_event_interval = 128;
+const progress_event_interval = 2048;
+const child_retention_slack_multiplier = 2;
+
+const DirectoryAggregate = aggregate_cache_module.DirectoryAggregate;
+const AggregateCache = aggregate_cache_module.MemoryCache;
+const PersistentAggregateCache = aggregate_cache_module.PersistentCache;
+
+const AggregateTask = struct {
+    path: []const u8,
+};
+
+const AggregateWorkerResult = struct {
+    aggregate: DirectoryAggregate = .{},
+    diagnostics: std.ArrayListUnmanaged(report.Diagnostic) = .empty,
+    failed: ?anyerror = null,
+};
+
+const AggregateWorkQueue = struct {
+    tasks: []const AggregateTask,
+    next_index: usize = 0,
+    mutex: std.atomic.Mutex = .unlocked,
+
+    fn next(self: *AggregateWorkQueue) ?usize {
+        while (!self.mutex.tryLock()) {
+            std.atomic.spinLoopHint();
+        }
+        defer self.mutex.unlock();
+
+        if (self.next_index >= self.tasks.len) return null;
+        const index = self.next_index;
+        self.next_index += 1;
+        return index;
+    }
+};
 
 pub fn scanPath(
     allocator: std.mem.Allocator,
@@ -21,6 +61,15 @@ pub fn scanPath(
     const started_at = std.Io.Clock.awake.now(io).nanoseconds;
     var diagnostics: std.ArrayListUnmanaged(report.Diagnostic) = .empty;
     errdefer freeDiagnostics(allocator, &diagnostics);
+    var summary = report_builder.initSummary();
+    errdefer report.freeSummary(allocator, &summary);
+    var aggregate_cache: AggregateCache = .empty;
+    defer aggregate_cache_module.freeMemory(allocator, &aggregate_cache);
+    var persistent_cache: PersistentAggregateCache = .empty;
+    defer aggregate_cache_module.freePersistent(allocator, &persistent_cache);
+    if (options.aggregate_cache_path) |cache_path| {
+        aggregate_cache_module.load(allocator, io, cache_path, &persistent_cache) catch {};
+    }
 
     var root = try scanNode(
         allocator,
@@ -30,15 +79,22 @@ pub fn scanPath(
         progress,
         event_writer,
         &diagnostics,
+        &summary,
+        &aggregate_cache,
+        &persistent_cache,
+        true,
+        null,
     );
     errdefer report.freeNode(allocator, &root);
 
     const elapsed_ns = std.Io.Clock.awake.now(io).nanoseconds - started_at;
     const duration_ms = @as(u64, @intCast(@max(elapsed_ns, 0))) / std.time.ns_per_ms;
-    const summary = try report.buildSummary(allocator, &root, diagnostics.items, duration_ms);
-    errdefer {
-        summary.largest_items.deinit(allocator);
-        summary.categories.deinit(allocator);
+    summary.duration_ms = duration_ms;
+    for (diagnostics.items) |diagnostic| {
+        report_builder.observeDiagnostic(&summary, diagnostic);
+    }
+    if (options.aggregate_cache_path) |cache_path| {
+        aggregate_cache_module.save(allocator, io, cache_path, &persistent_cache) catch {};
     }
 
     return .{ .root = root, .diagnostics = diagnostics, .summary = summary };
@@ -52,16 +108,29 @@ fn scanNode(
     progress: *events.ScanProgress,
     event_writer: anytype,
     diagnostics: *std.ArrayListUnmanaged(report.Diagnostic),
+    summary: *report.ScanSummary,
+    aggregate_cache: *AggregateCache,
+    persistent_cache: *PersistentAggregateCache,
+    is_root: bool,
+    known_kind: ?std.Io.File.Kind,
 ) !report.Node {
     const cwd = std.Io.Dir.cwd();
-    const stat = try cwd.statFile(io, absolute_path, .{});
-    const item_type = itemTypeFromKind(stat.kind);
+    const initial_kind = known_kind orelse .unknown;
+    const needs_stat = known_kind == null or initial_kind == .file or initial_kind == .unknown;
+    const stat: ?std.Io.File.Stat = if (needs_stat) try cwd.statFile(io, absolute_path, .{}) else null;
+    const file_kind = if (stat) |value| value.kind else initial_kind;
+    const item_type = itemTypeFromKind(file_kind);
     const name = std.fs.path.basename(absolute_path);
 
     progress.paths_scanned += 1;
-    progress.current_path = absolute_path;
-    if (item_type == .directory) progress.directories_scanned += 1;
-    if (item_type == .file) progress.files_scanned += 1;
+    if (item_type == .directory) {
+        progress.directories_scanned += 1;
+        progress.current_path = absolute_path;
+    }
+    if (item_type == .file) {
+        progress.files_scanned += 1;
+        progress.logical_size_scanned += stat.?.size;
+    }
     if (options.emit_events and shouldEmitProgressEvent(progress.*)) {
         try events.writeProgressEvent(event_writer, "progress", progress.*);
     }
@@ -70,15 +139,58 @@ fn scanNode(
         .path = try allocator.dupe(u8, absolute_path),
         .name = try allocator.dupe(u8, name),
         .item_type = item_type,
-        .logical_size = if (item_type == .file) stat.size else 0,
-        .allocated_size = allocatedSize(stat),
+        .logical_size = if (item_type == .file) stat.?.size else 0,
+        .allocated_size = allocatedSize(stat, item_type),
         .child_count = 0,
+        .omitted_child_count = 0,
         .status = .complete,
-        .classification = classification.classify(absolute_path, name),
+        .classification = scan_policy.classify(absolute_path, name),
         .children = .empty,
     };
 
     if (item_type != .directory) {
+        try report_builder.observeNode(allocator, summary, &node, is_root);
+        return node;
+    }
+
+    if (scan_policy.shouldSummarizeGeneratedDirectory(absolute_path, name, is_root)) {
+        const aggregate = summarizeDirectory(
+            allocator,
+            io,
+            absolute_path,
+            options,
+            progress,
+            event_writer,
+            diagnostics,
+            aggregate_cache,
+            persistent_cache,
+        ) catch |err| {
+            node.status = .failed;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                absolute_path,
+                .inaccessible,
+                .warning,
+                diagnosticMessage(err),
+                diagnosticGuidance(err),
+            );
+            try report_builder.observeSummarizedDirectory(allocator, summary, &node, is_root, 0, 0);
+            return node;
+        };
+
+        node.logical_size = aggregate.logical_size;
+        node.child_count = aggregate.child_count;
+        node.omitted_child_count = aggregate.child_count;
+        node.status = aggregate.status;
+        try report_builder.observeSummarizedDirectory(
+            allocator,
+            summary,
+            &node,
+            is_root,
+            aggregate.file_count,
+            aggregate.directory_count,
+        );
         return node;
     }
 
@@ -93,6 +205,7 @@ fn scanNode(
             diagnosticMessage(err),
             diagnosticGuidance(err),
         );
+        try report_builder.observeNode(allocator, summary, &node, is_root);
         return node;
     };
     defer dir.close(io);
@@ -116,6 +229,20 @@ fn scanNode(
         const child_path = try std.fs.path.join(allocator, &.{ absolute_path, entry.name });
         defer allocator.free(child_path);
 
+        if (isExcludedPath(child_path, options.exclude_paths)) {
+            node.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                child_path,
+                .skipped,
+                .warning,
+                "Skipped by scan exclude rule",
+                "Remove this path from scan excludes to include it.",
+            );
+            continue;
+        }
+
         const child = scanNode(
             allocator,
             io,
@@ -124,6 +251,11 @@ fn scanNode(
             progress,
             event_writer,
             diagnostics,
+            summary,
+            aggregate_cache,
+            persistent_cache,
+            false,
+            entry.kind,
         ) catch |err| {
             node.status = .partial;
             try appendDiagnostic(
@@ -142,13 +274,562 @@ fn scanNode(
         node.child_count += 1;
         if (child.status != .complete) node.status = .partial;
         try node.children.append(allocator, child);
+        if (node.children.items.len > options.max_children_per_directory * child_retention_slack_multiplier) {
+            report_builder.retainTopChildren(allocator, &node, options.max_children_per_directory);
+        }
     }
 
+    report_builder.retainTopChildren(allocator, &node, options.max_children_per_directory);
+    try report_builder.observeNode(allocator, summary, &node, is_root);
     return node;
 }
 
 fn shouldEmitProgressEvent(progress: events.ScanProgress) bool {
     return progress.paths_scanned == 1 or progress.paths_scanned % progress_event_interval == 0;
+}
+
+fn summarizeDirectory(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    absolute_path: []const u8,
+    options: ScanOptions,
+    progress: *events.ScanProgress,
+    event_writer: anytype,
+    diagnostics: *std.ArrayListUnmanaged(report.Diagnostic),
+    aggregate_cache: *AggregateCache,
+    persistent_cache: *PersistentAggregateCache,
+) anyerror!DirectoryAggregate {
+    const cache_key = try scan_policy.createReusableAggregateKey(allocator, absolute_path);
+    defer if (cache_key) |key| allocator.free(key);
+    const directory_stat = if (cache_key != null) try std.Io.Dir.cwd().statFile(io, absolute_path, .{}) else null;
+    if (cache_key) |key| {
+        if (aggregate_cache_module.getMemory(aggregate_cache, key)) |cached| {
+            progress.paths_scanned += cached.file_count + cached.directory_count;
+            progress.files_scanned += cached.file_count;
+            progress.directories_scanned += cached.directory_count;
+            progress.logical_size_scanned += cached.logical_size;
+            if (options.emit_events and shouldEmitProgressEvent(progress.*)) {
+                try events.writeProgressEvent(event_writer, "progress", progress.*);
+            }
+            return cached;
+        }
+        if (directory_stat) |stat| {
+            if (aggregate_cache_module.getPersistent(persistent_cache, key, stat)) |cached| {
+                progress.paths_scanned += cached.file_count + cached.directory_count;
+                progress.files_scanned += cached.file_count;
+                progress.directories_scanned += cached.directory_count;
+                progress.logical_size_scanned += cached.logical_size;
+                if (options.emit_events and shouldEmitProgressEvent(progress.*)) {
+                    try events.writeProgressEvent(event_writer, "progress", progress.*);
+                }
+                try aggregate_cache_module.putMemoryComplete(allocator, aggregate_cache, key, cached);
+                return cached;
+            }
+        }
+    }
+
+    if (!options.deep_scan_generated) {
+        const approximate_stat = directory_stat orelse try std.Io.Dir.cwd().statFile(io, absolute_path, .{});
+        const aggregate = DirectoryAggregate{
+            .logical_size = approximate_stat.size,
+            .file_count = 0,
+            .directory_count = 0,
+            .child_count = 0,
+            .status = .complete,
+        };
+        progress.logical_size_scanned += aggregate.logical_size;
+        if (options.emit_events and shouldEmitProgressEvent(progress.*)) {
+            try events.writeProgressEvent(event_writer, "progress", progress.*);
+        }
+        return aggregate;
+    }
+
+    const aggregate = if (options.max_aggregate_workers > 1)
+        try summarizeDirectoryParallel(
+            allocator,
+            io,
+            absolute_path,
+            options,
+            progress,
+            event_writer,
+            diagnostics,
+            aggregate_cache,
+            cache_key,
+        )
+    else
+        try summarizeDirectorySequential(
+            allocator,
+            io,
+            absolute_path,
+            options,
+            progress,
+            event_writer,
+            diagnostics,
+            aggregate_cache,
+            cache_key,
+            persistent_cache,
+        );
+
+    if (cache_key) |key| {
+        if (directory_stat) |stat| {
+            if (aggregate.status == .complete) {
+                try aggregate_cache_module.putPersistentComplete(allocator, persistent_cache, key, stat, aggregate);
+            }
+        }
+    }
+    return aggregate;
+}
+
+fn summarizeDirectorySequential(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    absolute_path: []const u8,
+    options: ScanOptions,
+    progress: *events.ScanProgress,
+    event_writer: anytype,
+    diagnostics: *std.ArrayListUnmanaged(report.Diagnostic),
+    aggregate_cache: *AggregateCache,
+    cache_key: ?[]const u8,
+    persistent_cache: *PersistentAggregateCache,
+) anyerror!DirectoryAggregate {
+    var aggregate = DirectoryAggregate{};
+    var dir = try std.Io.Dir.openDirAbsolute(io, absolute_path, .{ .iterate = true });
+    defer dir.close(io);
+
+    var iterator = dir.iterate();
+    while (true) {
+        const maybe_entry = iterator.next(io) catch |err| {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                absolute_path,
+                .inaccessible,
+                .warning,
+                diagnosticMessage(err),
+                diagnosticGuidance(err),
+            );
+            break;
+        };
+        const entry = maybe_entry orelse break;
+        const child_path = try std.fs.path.join(allocator, &.{ absolute_path, entry.name });
+        defer allocator.free(child_path);
+
+        aggregate.child_count += 1;
+        if (isExcludedPath(child_path, options.exclude_paths)) {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                child_path,
+                .skipped,
+                .warning,
+                "Skipped by scan exclude rule",
+                "Remove this path from scan excludes to include it.",
+            );
+            continue;
+        }
+
+        const initial_kind = entry.kind;
+        const needs_stat = initial_kind == .file or initial_kind == .unknown;
+        const stat: ?std.Io.File.Stat = if (needs_stat) std.Io.Dir.cwd().statFile(io, child_path, .{}) catch |err| {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                child_path,
+                .skipped,
+                .warning,
+                diagnosticMessage(err),
+                diagnosticGuidance(err),
+            );
+            continue;
+        } else null;
+        const file_kind = if (stat) |value| value.kind else initial_kind;
+        const item_type = itemTypeFromKind(file_kind);
+
+        progress.paths_scanned += 1;
+        if (item_type == .directory) {
+            progress.directories_scanned += 1;
+            aggregate.directory_count += 1;
+        }
+        if (item_type == .file) {
+            const size = stat.?.size;
+            progress.files_scanned += 1;
+            progress.logical_size_scanned += size;
+            aggregate.file_count += 1;
+            aggregate.logical_size += size;
+        }
+        if (options.emit_events and shouldEmitProgressEvent(progress.*)) {
+            try events.writeProgressEvent(event_writer, "progress", progress.*);
+        }
+
+        if (item_type == .directory) {
+            const child_aggregate = summarizeDirectory(
+                allocator,
+                io,
+                child_path,
+                options,
+                progress,
+                event_writer,
+                diagnostics,
+                aggregate_cache,
+                persistent_cache,
+            ) catch |err| {
+                aggregate.status = .partial;
+                try appendDiagnostic(
+                    allocator,
+                    diagnostics,
+                    child_path,
+                    .inaccessible,
+                    .warning,
+                    diagnosticMessage(err),
+                    diagnosticGuidance(err),
+                );
+                continue;
+            };
+            aggregate.logical_size += child_aggregate.logical_size;
+            aggregate.file_count += child_aggregate.file_count;
+            aggregate.directory_count += child_aggregate.directory_count;
+            if (child_aggregate.status != .complete) aggregate.status = .partial;
+        }
+    }
+
+    if (cache_key) |key| {
+        if (aggregate.status == .complete) {
+            try aggregate_cache_module.putMemoryComplete(allocator, aggregate_cache, key, aggregate);
+        }
+    }
+
+    return aggregate;
+}
+
+fn summarizeDirectoryParallel(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    absolute_path: []const u8,
+    options: ScanOptions,
+    progress: *events.ScanProgress,
+    event_writer: anytype,
+    diagnostics: *std.ArrayListUnmanaged(report.Diagnostic),
+    aggregate_cache: *AggregateCache,
+    cache_key: ?[]const u8,
+) anyerror!DirectoryAggregate {
+    var aggregate = DirectoryAggregate{};
+    var directory_tasks: std.ArrayListUnmanaged(AggregateTask) = .empty;
+    defer {
+        for (directory_tasks.items) |task| allocator.free(task.path);
+        directory_tasks.deinit(allocator);
+    }
+
+    var dir = try std.Io.Dir.openDirAbsolute(io, absolute_path, .{ .iterate = true });
+    defer dir.close(io);
+
+    var iterator = dir.iterate();
+    while (true) {
+        const maybe_entry = iterator.next(io) catch |err| {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                absolute_path,
+                .inaccessible,
+                .warning,
+                diagnosticMessage(err),
+                diagnosticGuidance(err),
+            );
+            break;
+        };
+        const entry = maybe_entry orelse break;
+        const child_path = try std.fs.path.join(allocator, &.{ absolute_path, entry.name });
+        errdefer allocator.free(child_path);
+
+        aggregate.child_count += 1;
+        if (isExcludedPath(child_path, options.exclude_paths)) {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                child_path,
+                .skipped,
+                .warning,
+                "Skipped by scan exclude rule",
+                "Remove this path from scan excludes to include it.",
+            );
+            allocator.free(child_path);
+            continue;
+        }
+
+        const initial_kind = entry.kind;
+        const needs_stat = initial_kind == .file or initial_kind == .unknown;
+        const stat: ?std.Io.File.Stat = if (needs_stat) std.Io.Dir.cwd().statFile(io, child_path, .{}) catch |err| {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                child_path,
+                .skipped,
+                .warning,
+                diagnosticMessage(err),
+                diagnosticGuidance(err),
+            );
+            allocator.free(child_path);
+            continue;
+        } else null;
+        const file_kind = if (stat) |value| value.kind else initial_kind;
+        const item_type = itemTypeFromKind(file_kind);
+
+        progress.paths_scanned += 1;
+        if (item_type == .directory) {
+            progress.directories_scanned += 1;
+            aggregate.directory_count += 1;
+            try directory_tasks.append(allocator, .{ .path = child_path });
+        } else {
+            allocator.free(child_path);
+        }
+        if (item_type == .file) {
+            const size = stat.?.size;
+            progress.files_scanned += 1;
+            progress.logical_size_scanned += size;
+            aggregate.file_count += 1;
+            aggregate.logical_size += size;
+        }
+        if (options.emit_events and shouldEmitProgressEvent(progress.*)) {
+            try events.writeProgressEvent(event_writer, "progress", progress.*);
+        }
+    }
+
+    if (directory_tasks.items.len == 0) {
+        try aggregate_cache_module.putMemoryComplete(allocator, aggregate_cache, cache_key, aggregate);
+        return aggregate;
+    }
+
+    const results = try allocator.alloc(AggregateWorkerResult, directory_tasks.items.len);
+    defer allocator.free(results);
+    for (results) |*result| result.* = .{};
+
+    var queue = AggregateWorkQueue{ .tasks = directory_tasks.items };
+    const worker_count = @min(options.max_aggregate_workers, directory_tasks.items.len);
+    const threads = try allocator.alloc(std.Thread, worker_count);
+    defer allocator.free(threads);
+
+    for (threads, 0..) |*thread, index| {
+        thread.* = try std.Thread.spawn(.{}, aggregateWorkerMain, .{
+            &queue,
+            directory_tasks.items,
+            results,
+            io,
+            options,
+            index,
+        });
+    }
+    for (threads) |thread| thread.join();
+
+    for (results, 0..) |*result, index| {
+        defer freeDiagnostics(std.heap.smp_allocator, &result.diagnostics);
+        const task_path = directory_tasks.items[index].path;
+        if (result.failed) |err| {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                task_path,
+                .inaccessible,
+                .warning,
+                diagnosticMessage(err),
+                diagnosticGuidance(err),
+            );
+            continue;
+        }
+
+        aggregate.logical_size += result.aggregate.logical_size;
+        aggregate.file_count += result.aggregate.file_count;
+        aggregate.directory_count += result.aggregate.directory_count;
+        if (result.aggregate.status != .complete) aggregate.status = .partial;
+        progress.paths_scanned += result.aggregate.file_count + result.aggregate.directory_count;
+        progress.files_scanned += result.aggregate.file_count;
+        progress.directories_scanned += result.aggregate.directory_count;
+        progress.logical_size_scanned += result.aggregate.logical_size;
+        for (result.diagnostics.items) |diagnostic| {
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                diagnostic.path,
+                diagnostic.kind,
+                diagnostic.severity,
+                diagnostic.message,
+                diagnostic.guidance,
+            );
+        }
+        if (options.emit_events and shouldEmitProgressEvent(progress.*)) {
+            try events.writeProgressEvent(event_writer, "progress", progress.*);
+        }
+    }
+
+    try aggregate_cache_module.putMemoryComplete(allocator, aggregate_cache, cache_key, aggregate);
+    return aggregate;
+}
+
+fn aggregateWorkerMain(
+    queue: *AggregateWorkQueue,
+    tasks: []const AggregateTask,
+    results: []AggregateWorkerResult,
+    io: std.Io,
+    options: ScanOptions,
+    worker_index: usize,
+) void {
+    _ = worker_index;
+    while (queue.next()) |task_index| {
+        var local_cache: AggregateCache = .empty;
+        defer aggregate_cache_module.freeMemory(std.heap.smp_allocator, &local_cache);
+        var progress = events.ScanProgress{};
+        results[task_index].aggregate = summarizeDirectoryQuiet(
+            std.heap.smp_allocator,
+            io,
+            tasks[task_index].path,
+            options,
+            &progress,
+            &results[task_index].diagnostics,
+            &local_cache,
+        ) catch |err| {
+            results[task_index].failed = err;
+            continue;
+        };
+    }
+}
+
+fn summarizeDirectoryQuiet(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    absolute_path: []const u8,
+    options: ScanOptions,
+    progress: *events.ScanProgress,
+    diagnostics: *std.ArrayListUnmanaged(report.Diagnostic),
+    aggregate_cache: *AggregateCache,
+) anyerror!DirectoryAggregate {
+    const cache_key = try scan_policy.createReusableAggregateKey(allocator, absolute_path);
+    defer if (cache_key) |key| allocator.free(key);
+    if (cache_key) |key| {
+        if (aggregate_cache_module.getMemory(aggregate_cache, key)) |cached| {
+            progress.paths_scanned += cached.file_count + cached.directory_count;
+            progress.files_scanned += cached.file_count;
+            progress.directories_scanned += cached.directory_count;
+            progress.logical_size_scanned += cached.logical_size;
+            return cached;
+        }
+    }
+
+    var aggregate = DirectoryAggregate{};
+    var dir = try std.Io.Dir.openDirAbsolute(io, absolute_path, .{ .iterate = true });
+    defer dir.close(io);
+
+    var iterator = dir.iterate();
+    while (true) {
+        const maybe_entry = iterator.next(io) catch |err| {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                absolute_path,
+                .inaccessible,
+                .warning,
+                diagnosticMessage(err),
+                diagnosticGuidance(err),
+            );
+            break;
+        };
+        const entry = maybe_entry orelse break;
+        const child_path = try std.fs.path.join(allocator, &.{ absolute_path, entry.name });
+        defer allocator.free(child_path);
+
+        aggregate.child_count += 1;
+        if (isExcludedPath(child_path, options.exclude_paths)) {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                child_path,
+                .skipped,
+                .warning,
+                "Skipped by scan exclude rule",
+                "Remove this path from scan excludes to include it.",
+            );
+            continue;
+        }
+
+        const initial_kind = entry.kind;
+        const needs_stat = initial_kind == .file or initial_kind == .unknown;
+        const stat: ?std.Io.File.Stat = if (needs_stat) std.Io.Dir.cwd().statFile(io, child_path, .{}) catch |err| {
+            aggregate.status = .partial;
+            try appendDiagnostic(
+                allocator,
+                diagnostics,
+                child_path,
+                .skipped,
+                .warning,
+                diagnosticMessage(err),
+                diagnosticGuidance(err),
+            );
+            continue;
+        } else null;
+        const file_kind = if (stat) |value| value.kind else initial_kind;
+        const item_type = itemTypeFromKind(file_kind);
+
+        progress.paths_scanned += 1;
+        if (item_type == .directory) {
+            progress.directories_scanned += 1;
+            aggregate.directory_count += 1;
+        }
+        if (item_type == .file) {
+            const size = stat.?.size;
+            progress.files_scanned += 1;
+            progress.logical_size_scanned += size;
+            aggregate.file_count += 1;
+            aggregate.logical_size += size;
+        }
+
+        if (item_type == .directory) {
+            const child_aggregate = summarizeDirectoryQuiet(
+                allocator,
+                io,
+                child_path,
+                options,
+                progress,
+                diagnostics,
+                aggregate_cache,
+            ) catch |err| {
+                aggregate.status = .partial;
+                try appendDiagnostic(
+                    allocator,
+                    diagnostics,
+                    child_path,
+                    .inaccessible,
+                    .warning,
+                    diagnosticMessage(err),
+                    diagnosticGuidance(err),
+                );
+                continue;
+            };
+            aggregate.logical_size += child_aggregate.logical_size;
+            aggregate.file_count += child_aggregate.file_count;
+            aggregate.directory_count += child_aggregate.directory_count;
+            if (child_aggregate.status != .complete) aggregate.status = .partial;
+        }
+    }
+
+    try aggregate_cache_module.putMemoryComplete(allocator, aggregate_cache, cache_key, aggregate);
+    return aggregate;
+}
+
+fn isExcludedPath(path: []const u8, exclude_paths: []const []const u8) bool {
+    for (exclude_paths) |exclude_path| {
+        if (exclude_path.len == 0) continue;
+        if (std.mem.eql(u8, path, exclude_path)) return true;
+        if (std.mem.startsWith(u8, path, exclude_path) and path.len > exclude_path.len and path[exclude_path.len] == std.fs.path.sep) {
+            return true;
+        }
+    }
+    return false;
 }
 
 fn appendDiagnostic(
@@ -211,7 +892,8 @@ fn itemTypeFromKind(kind: std.Io.File.Kind) report.ItemType {
     };
 }
 
-fn allocatedSize(stat: std.Io.File.Stat) ?u64 {
-    if (stat.kind == .directory) return null;
-    return stat.size;
+fn allocatedSize(stat: ?std.Io.File.Stat, item_type: report.ItemType) ?u64 {
+    if (item_type == .directory) return null;
+    if (stat) |value| return value.size;
+    return null;
 }

--- a/packages/scanner/src/cli.ts
+++ b/packages/scanner/src/cli.ts
@@ -4,10 +4,34 @@ import { runScan } from "./run";
 
 const args = process.argv.slice(2);
 const jsonOnly = args.includes("--json");
-const targetPath = args.find((arg) => arg !== "--json") ?? ".";
+const deepScanGenerated = args.includes("--deep-scan");
+const excludedPaths: string[] = [];
+const positionalArgs: string[] = [];
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
+  if (!arg) continue;
+  if (arg === "--json") continue;
+  if (arg === "--deep-scan") continue;
+  if (arg === "--exclude") {
+    const excludedPath = args[index + 1];
+    if (typeof excludedPath !== "string") {
+      process.stderr.write("usage: zpace scan [--json] [--deep-scan] [--exclude <path>] <path>\n");
+      process.exit(64);
+    }
+    excludedPaths.push(excludedPath);
+    index += 1;
+    continue;
+  }
+  positionalArgs.push(arg);
+}
+
+const targetPath = positionalArgs[0] ?? ".";
 
 const scan = runScan({
   path: targetPath,
+  excludedPaths,
+  deepScanGenerated,
   onEvent(event) {
     if (jsonOnly) return;
 

--- a/packages/scanner/src/contract.test.ts
+++ b/packages/scanner/src/contract.test.ts
@@ -22,16 +22,15 @@ describe("native scanner contract", () => {
       expect(result.root.path).toBe(root);
       expect(result.root.status).toBe("complete");
       expect(result.root.children.some((child) => child.name === "src")).toBe(true);
-      expect(result.summary.totalLogicalSize).toBe(5);
+      expect(result.summary.totalLogicalSize).toBeGreaterThanOrEqual(5);
       expect(result.summary.fileCount).toBe(1);
       expect(result.summary.folderCount).toBe(3);
       expect(result.summary.inaccessibleCount).toBe(0);
       expect(result.summary.skippedCount).toBe(0);
       expect(result.summary.freeSize).toBeNull();
       expect(result.summary.purgeableSize).toBeNull();
-      expect(result.summary.largestItems[0]?.name).toBe("main.txt");
+      expect(result.summary.largestItems.some((item) => item.name === "main.txt")).toBe(true);
       expect(result.summary.categories.find((item) => item.category === "Developer artifacts")).toMatchObject({
-        logicalSize: 0,
         itemCount: 1,
       });
       expect(result.root.children.find((child) => child.name === "node_modules")?.classification).toMatchObject({
@@ -67,6 +66,167 @@ describe("native scanner contract", () => {
       });
     } finally {
       await chmod(inaccessiblePath, 0o700).catch(() => {});
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("bounds serialized children while preserving summary totals", async () => {
+    const root = await mkdtemp(join(tmpdir(), "zpace-bounded-"));
+
+    try {
+      for (let index = 0; index < 80; index += 1) {
+        await writeFile(join(root, `file-${index.toString().padStart(2, "0")}.txt`), "x");
+      }
+
+      const scan = runScan({ path: root });
+      const result = await scan.completed;
+
+      expect(result.root.childCount).toBe(80);
+      expect(result.root.children.length).toBe(64);
+      expect(result.root.childrenTruncated).toBe(true);
+      expect(result.root.omittedChildCount).toBe(16);
+      expect(result.summary.fileCount).toBe(80);
+      expect(result.summary.totalLogicalSize).toBe(80);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("summarizes generated dependency subtrees approximately by default", async () => {
+    const root = await mkdtemp(join(tmpdir(), "zpace-generated-"));
+    const dependencyRoot = join(root, "node_modules");
+
+    try {
+      await mkdir(join(dependencyRoot, "pkg", "lib"), { recursive: true });
+      await writeFile(join(dependencyRoot, "pkg", "lib", "index.js"), "dependency");
+
+      const scan = runScan({ path: root });
+      const result = await scan.completed;
+      const nodeModules = result.root.children.find((child) => child.name === "node_modules");
+
+      expect(nodeModules).toMatchObject({
+        childCount: 0,
+        omittedChildCount: 0,
+        childrenTruncated: false,
+        children: [],
+      });
+      expect(nodeModules?.logicalSize).toBeGreaterThanOrEqual(0);
+      expect(result.summary.fileCount).toBe(0);
+      expect(result.summary.folderCount).toBe(2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("deep scan keeps exact generated dependency subtree totals", async () => {
+    const root = await mkdtemp(join(tmpdir(), "zpace-generated-deep-"));
+    const dependencyRoot = join(root, "node_modules");
+
+    try {
+      await mkdir(join(dependencyRoot, "pkg", "lib"), { recursive: true });
+      await writeFile(join(dependencyRoot, "pkg", "lib", "index.js"), "dependency");
+
+      const scan = runScan({ path: root, deepScanGenerated: true });
+      const result = await scan.completed;
+      const nodeModules = result.root.children.find((child) => child.name === "node_modules");
+
+      expect(nodeModules).toMatchObject({
+        logicalSize: 10,
+        childCount: 1,
+        omittedChildCount: 1,
+        childrenTruncated: true,
+        children: [],
+      });
+      expect(result.summary.totalLogicalSize).toBe(10);
+      expect(result.summary.fileCount).toBe(1);
+      expect(result.summary.folderCount).toBe(4);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("deep scan of a generated root expands visible children", async () => {
+    const root = await mkdtemp(join(tmpdir(), "zpace-generated-root-"));
+    const dependencyRoot = join(root, ".venv");
+
+    try {
+      await mkdir(join(dependencyRoot, "lib"), { recursive: true });
+      await writeFile(join(dependencyRoot, "lib", "site.py"), "dependency");
+
+      const scan = runScan({ path: dependencyRoot, deepScanGenerated: true });
+      const result = await scan.completed;
+
+      expect(result.root).toMatchObject({
+        name: ".venv",
+        logicalSize: 10,
+        childCount: 1,
+        omittedChildCount: 0,
+        childrenTruncated: false,
+      });
+      expect(result.root.children.map((child) => child.name)).toEqual(["lib"]);
+      expect(result.summary.totalLogicalSize).toBe(10);
+      expect(result.summary.fileCount).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("counts duplicate package-manager store entries at each location", async () => {
+    const root = await mkdtemp(join(tmpdir(), "zpace-store-cache-"));
+
+    try {
+      for (const project of ["app-a", "app-b"]) {
+        const packageRoot = join(
+          root,
+          project,
+          "node_modules",
+          ".bun",
+          "entities@4.5.0+samehash",
+          "node_modules",
+          "entities",
+        );
+        await mkdir(packageRoot, { recursive: true });
+        await writeFile(join(packageRoot, "index.js"), "shared");
+      }
+
+      const scan = runScan({ path: root, deepScanGenerated: true });
+      const result = await scan.completed;
+
+      expect(result.summary.totalLogicalSize).toBe(12);
+      expect(result.summary.fileCount).toBe(2);
+      expect(result.summary.folderCount).toBe(13);
+      expect(result.root.children.map((child) => child.name)).toEqual(["app-a", "app-b"]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("skips excluded subtrees and reports them as diagnostics", async () => {
+    const root = await mkdtemp(join(tmpdir(), "zpace-excludes-"));
+    const keptPath = join(root, "kept.txt");
+    const skippedPath = join(root, "skip-me");
+
+    try {
+      await writeFile(keptPath, "kept");
+      await mkdir(skippedPath);
+      await writeFile(join(skippedPath, "ignored.txt"), "ignored");
+
+      const scan = runScan({ path: root, excludedPaths: [skippedPath] });
+      const result = await scan.completed;
+
+      expect(result.root.status).toBe("partial");
+      expect(result.summary.fileCount).toBe(1);
+      expect(result.summary.totalLogicalSize).toBe(4);
+      expect(result.summary.skippedCount).toBe(1);
+      expect(result.root.children.map((child) => child.name)).toEqual(["kept.txt"]);
+      expect(result.diagnostics).toContainEqual({
+        path: skippedPath,
+        kind: "skipped",
+        severity: "warning",
+        message: "Skipped by scan exclude rule",
+        guidance: "Remove this path from scan excludes to include it.",
+      });
+    } finally {
       await rm(root, { recursive: true, force: true });
     }
   }, 20_000);

--- a/packages/scanner/src/presentation.ts
+++ b/packages/scanner/src/presentation.ts
@@ -41,7 +41,10 @@ export function summarizeScanSnapshot(snapshot: ScanLifecycleSnapshot): ScanLabe
   return [
     { label: "paths", value: snapshot.progress.pathsScanned.toString() },
     { label: "files", value: snapshot.progress.filesScanned.toString() },
-    { label: "size", value: snapshot.result ? formatBytes(snapshot.result.root.logicalSize) : "-" },
+    {
+      label: "size",
+      value: formatBytes(snapshot.result?.root.logicalSize ?? snapshot.progress.logicalSizeScanned),
+    },
     { label: "warnings", value: snapshot.result?.diagnostics.length.toString() ?? "0" },
     { label: "state", value: snapshot.state },
   ];

--- a/packages/scanner/src/run.test.ts
+++ b/packages/scanner/src/run.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { createScannerCommand } from "./run";
 import {
   applyLifecycleEvent,
   cancelScan,
@@ -24,6 +25,7 @@ describe("scan lifecycle state", () => {
         pathsScanned: 2,
         directoriesScanned: 1,
         filesScanned: 1,
+        logicalSizeScanned: 5,
         currentPath: "/tmp/zpace/package.json",
       },
     });
@@ -35,6 +37,7 @@ describe("scan lifecycle state", () => {
         pathsScanned: 2,
         directoriesScanned: 1,
         filesScanned: 1,
+        logicalSizeScanned: 5,
         currentPath: null,
       },
     });
@@ -52,6 +55,7 @@ describe("scan lifecycle state", () => {
         pathsScanned: 99,
         directoriesScanned: 9,
         filesScanned: 90,
+        logicalSizeScanned: 900,
         currentPath: "/late",
       },
     });
@@ -89,6 +93,27 @@ describe("scan lifecycle state", () => {
   });
 });
 
+describe("scanner command", () => {
+  test("uses a packaged scanner executable without requiring a scanner source root", () => {
+    expect(
+      createScannerCommand(
+        "/tmp/zpace",
+        "/missing/source-root",
+        ["/tmp/zpace/.git"],
+        true,
+        "/Applications/zpace.app/Contents/Resources/app/scanner/zpace-scanner",
+      ),
+    ).toEqual([
+      "/Applications/zpace.app/Contents/Resources/app/scanner/zpace-scanner",
+      "--events",
+      "--deep-scan",
+      "--exclude",
+      "/tmp/zpace/.git",
+      "/tmp/zpace",
+    ]);
+  });
+});
+
 function scanResult(): ScanResult {
   return {
     schemaVersion: 1,
@@ -99,6 +124,8 @@ function scanResult(): ScanResult {
       logicalSize: 0,
       allocatedSize: null,
       childCount: 0,
+      omittedChildCount: 0,
+      childrenTruncated: false,
       status: "complete",
       classification: null,
       children: [],

--- a/packages/scanner/src/run.ts
+++ b/packages/scanner/src/run.ts
@@ -27,66 +27,107 @@ export interface ScanRun {
 
 export interface RunScanOptions {
   path: string;
+  scannerRoot?: string;
+  scannerExecutablePath?: string;
+  excludedPaths?: string[];
+  deepScanGenerated?: boolean;
   onEvent?: (event: ScanLifecycleEvent, snapshot: ScanLifecycleSnapshot) => void;
 }
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const scannerBuilds = new Map<string, Promise<void>>();
 
-export function createScannerCommand(path: string): string[] {
-  return [
-    "zig",
-    "build",
-    "--build-file",
-    resolve(packageRoot, "native/build.zig"),
-    "run",
-    "--",
+export function createScannerBuildCommand(scannerRoot = packageRoot): string[] {
+  return ["zig", "build", "--build-file", resolve(scannerRoot, "native/build.zig")];
+}
+
+export function createScannerExecutablePath(scannerRoot = packageRoot): string {
+  return resolve(scannerRoot, "native/zig-out/bin/zpace-scanner");
+}
+
+export function createScannerCommand(
+  path: string,
+  scannerRoot = packageRoot,
+  excludedPaths: string[] = [],
+  deepScanGenerated = false,
+  scannerExecutablePath?: string,
+): string[] {
+  const cmd = [
+    scannerExecutablePath ?? createScannerExecutablePath(scannerRoot),
     "--events",
-    resolve(process.cwd(), path),
   ];
+  if (deepScanGenerated) {
+    cmd.push("--deep-scan");
+  }
+  for (const excludedPath of excludedPaths) {
+    cmd.push("--exclude", resolve(process.cwd(), excludedPath));
+  }
+  cmd.push(resolve(process.cwd(), path));
+  return cmd;
 }
 
 export function runScan(options: RunScanOptions): ScanRun {
   const snapshot = createInitialScanLifecycleSnapshot();
-
-  const scanner = Bun.spawn({
-    cmd: createScannerCommand(options.path),
-    cwd: packageRoot,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  void readLifecycleEvents(scanner.stderr, (event) => {
-    applyLifecycleEvent(snapshot, event);
-    options.onEvent?.(event, snapshot);
-  }).catch(() => undefined);
+  const scannerRoot = options.scannerRoot ?? packageRoot;
+  const scannerExecutablePath = options.scannerExecutablePath;
+  const scannerCwd = scannerExecutablePath ? dirname(scannerExecutablePath) : scannerRoot;
+  let scanner: ReturnType<typeof Bun.spawn> | null = null;
+  let cancelled = false;
 
   const completed = (async () => {
-    const stdout = await new Response(scanner.stdout).text();
-    const exitCode = await scanner.exited;
-
-    if (exitCode !== 0) {
-      if (snapshot.state === "cancelled") {
+    try {
+      await ensureScannerExecutable(scannerRoot, scannerExecutablePath);
+      if (cancelled || snapshot.state === "cancelled") {
         throw new Error("Scan cancelled");
       }
-      const error = new Error(`Zig scanner exited with status ${exitCode}`);
-      failScan(snapshot, error);
-      throw error;
-    }
 
-    const parsedJson = parseJson(stdout);
-    if (!parsedJson.ok) {
-      failScan(snapshot, parsedJson.error);
-      throw parsedJson.error;
-    }
+      scanner = Bun.spawn({
+        cmd: createScannerCommand(
+          options.path,
+          scannerRoot,
+          options.excludedPaths ?? [],
+          options.deepScanGenerated ?? false,
+          scannerExecutablePath,
+        ),
+        cwd: scannerCwd,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const scannerStdout = requireReadableStream(scanner.stdout, "scanner stdout");
+      const scannerStderr = requireReadableStream(scanner.stderr, "scanner stderr");
 
-    const parsed = scanResultSchema.safeParse(parsedJson.value);
-    if (!parsed.success) {
-      failScan(snapshot, parsed.error);
-      throw parsed.error;
-    }
+      const stderrText = readLifecycleEvents(scannerStderr, (event) => {
+        applyLifecycleEvent(snapshot, event);
+        options.onEvent?.(event, snapshot);
+      }).catch(() => "");
 
-    completeScan(snapshot, parsed.data);
-    return parsed.data;
+      const stdout = await new Response(scannerStdout).text();
+      const stderr = await stderrText;
+      const exitCode = await scanner.exited;
+
+      if (exitCode !== 0) {
+        if (cancelled) {
+          throw new Error("Scan cancelled");
+        }
+        throw new Error(formatScannerFailure(exitCode, stderr));
+      }
+
+      const parsedJson = parseJson(stdout);
+      if (!parsedJson.ok) throw parsedJson.error;
+
+      const parsed = scanResultSchema.safeParse(parsedJson.value);
+      if (!parsed.success) throw parsed.error;
+
+      completeScan(snapshot, parsed.data);
+      return parsed.data;
+    } catch (error) {
+      const normalizedError = error instanceof Error ? error : new Error("Scanner failed");
+      if (cancelled) {
+        throw new Error("Scan cancelled");
+      }
+      failScan(snapshot, normalizedError);
+      throw normalizedError;
+    }
   })();
 
   return {
@@ -94,19 +135,70 @@ export function runScan(options: RunScanOptions): ScanRun {
     completed,
     cancel() {
       if (!isActiveScanState(snapshot.state)) return;
+      cancelled = true;
       cancelScan(snapshot);
-      scanner.kill();
+      scanner?.kill();
     },
   };
+}
+
+function ensureScannerExecutable(
+  scannerRoot: string,
+  scannerExecutablePath?: string,
+): Promise<void> {
+  if (scannerExecutablePath) {
+    return verifyScannerExecutable(scannerExecutablePath);
+  }
+
+  const existingBuild = scannerBuilds.get(scannerRoot);
+  if (existingBuild) return existingBuild;
+
+  const build = buildScannerExecutable(scannerRoot).catch((error) => {
+    scannerBuilds.delete(scannerRoot);
+    throw error;
+  });
+  scannerBuilds.set(scannerRoot, build);
+  return build;
+}
+
+async function verifyScannerExecutable(scannerExecutablePath: string): Promise<void> {
+  const executable = Bun.file(scannerExecutablePath);
+  if (await executable.exists()) return;
+  throw new Error(`Zig scanner executable was not found at ${scannerExecutablePath}`);
+}
+
+async function buildScannerExecutable(scannerRoot: string): Promise<void> {
+  const build = Bun.spawn({
+    cmd: createScannerBuildCommand(scannerRoot),
+    cwd: scannerRoot,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  const stderr = await new Response(requireReadableStream(build.stderr, "scanner build stderr")).text();
+  const exitCode = await build.exited;
+  if (exitCode === 0) return;
+
+  const detail = formatScannerFailure(exitCode, stderr);
+  throw new Error(`Zig scanner build failed:\n${detail}`);
+}
+
+function requireReadableStream(
+  value: ReadableStream<Uint8Array> | number | undefined,
+  name: string,
+): ReadableStream<Uint8Array> {
+  if (value instanceof ReadableStream) return value;
+  throw new Error(`${name} was not opened as a readable stream`);
 }
 
 async function readLifecycleEvents(
   stream: ReadableStream<Uint8Array>,
   onEvent: (event: ScanLifecycleEvent) => void,
-) {
+): Promise<string> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let text = "";
 
   const consumeLine = (line: string) => {
     if (!line.trim()) return;
@@ -120,14 +212,32 @@ async function readLifecycleEvents(
     const { done, value } = await reader.read();
     if (done) break;
 
-    buffer += decoder.decode(value, { stream: true });
+    const chunk = decoder.decode(value, { stream: true });
+    text += chunk;
+    buffer += chunk;
     const lines = buffer.split("\n");
     buffer = lines.pop() ?? "";
     for (const line of lines) consumeLine(line);
   }
 
-  buffer += decoder.decode();
+  const finalChunk = decoder.decode();
+  text += finalChunk;
+  buffer += finalChunk;
   consumeLine(buffer);
+  return text;
+}
+
+function formatScannerFailure(exitCode: number, stderr: string): string {
+  const detail = stderr
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("{\"type\":"))
+    .slice(-6)
+    .join("\n");
+
+  return detail
+    ? `Zig scanner exited with status ${exitCode}:\n${detail}`
+    : `Zig scanner exited with status ${exitCode}`;
 }
 
 function parseJson(text: string): { ok: true; value: unknown } | { ok: false; error: Error } {

--- a/packages/scanner/src/runtime.test.ts
+++ b/packages/scanner/src/runtime.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+
+import { createScanRuntime, type ScanSnapshotEmitter } from "./runtime";
+import {
+  initialScanProgress,
+  type ScanLifecycleSnapshot,
+  type ScanLifecycleState,
+  type ScanProgress,
+} from "./schema";
+
+describe("scan runtime", () => {
+  test("resolves defaults and emits starting snapshots before adapter work", () => {
+    const snapshots: ScanLifecycleSnapshot[] = [];
+    let observedRequest: unknown = null;
+
+    const runtime = createScanRuntime({
+      defaultPath: "/Users/erik",
+      defaultExcludedPaths: ["/Users/erik/Library/CloudStorage"],
+      onSnapshot(snapshot) {
+        snapshots.push(snapshot);
+      },
+      adapter: {
+        start(request) {
+          observedRequest = request;
+          return { cancel() {} };
+        },
+      },
+    });
+
+    const request = runtime.start();
+
+    expect(request).toEqual({
+      path: "/Users/erik",
+      excludedPaths: ["/Users/erik/Library/CloudStorage"],
+      deepScanGenerated: false,
+    });
+    expect(observedRequest).toEqual(request);
+    expect(snapshots[0]).toMatchObject({
+      state: "starting",
+      progress: { currentPath: "/Users/erik" },
+    });
+    expect(runtime.canCancel()).toBe(true);
+  });
+
+  test("cancels active work and suppresses stale snapshots", () => {
+    let emitSnapshot: ScanSnapshotEmitter | null = null;
+    let cancelCount = 0;
+    const runtime = createScanRuntime({
+      defaultPath: "/tmp/zpace",
+      adapter: {
+        start(_request, emit) {
+          emitSnapshot = emit;
+          emit(createSnapshot("running", { ...initialScanProgress, currentPath: "/tmp/zpace" }));
+          return {
+            cancel() {
+              cancelCount += 1;
+            },
+          };
+        },
+      },
+    });
+
+    runtime.start();
+    expect(runtime.snapshot.state).toBe("running");
+
+    expect(runtime.cancel()).toBe(true);
+    expect(cancelCount).toBe(1);
+    expect(runtime.snapshot.state).toBe("cancelled");
+    expect(runtime.snapshot.progress.currentPath).toBeNull();
+
+    expectEmitter(emitSnapshot)(
+      createSnapshot("complete", { ...initialScanProgress, currentPath: null }),
+    );
+    expect(runtime.snapshot.state).toBe("cancelled");
+  });
+
+  test("converts adapter start failures to error snapshots", () => {
+    const runtime = createScanRuntime({
+      defaultPath: "/tmp/zpace",
+      adapter: {
+        start() {
+          throw new Error("bad adapter");
+        },
+      },
+    });
+
+    runtime.start();
+
+    expect(runtime.snapshot.state).toBe("error");
+    expect(runtime.snapshot.error).toBe("bad adapter");
+    expect(runtime.canRescan()).toBe(true);
+  });
+});
+
+function createSnapshot(
+  state: ScanLifecycleState,
+  progress: ScanProgress,
+): ScanLifecycleSnapshot {
+  return {
+    state,
+    progress,
+    result: null,
+    error: null,
+  };
+}
+
+function expectEmitter(emitSnapshot: ScanSnapshotEmitter | null): ScanSnapshotEmitter {
+  expect(emitSnapshot).not.toBeNull();
+  return emitSnapshot as ScanSnapshotEmitter;
+}

--- a/packages/scanner/src/runtime.ts
+++ b/packages/scanner/src/runtime.ts
@@ -1,0 +1,140 @@
+import {
+  cancelScan,
+  createInitialScanLifecycleSnapshot,
+  failScan,
+  isActiveScanState,
+} from "./lifecycle";
+import { initialScanProgress, type ScanLifecycleSnapshot } from "./schema";
+
+export interface ScanRuntimeRequest {
+  path?: string;
+  excludedPaths?: string[];
+  deepScanGenerated?: boolean;
+}
+
+export interface ResolvedScanRuntimeRequest {
+  path: string;
+  excludedPaths: string[];
+  deepScanGenerated: boolean;
+}
+
+export type ScanSnapshotEmitter = (snapshot: ScanLifecycleSnapshot) => void;
+
+export interface ScanRuntimeRun {
+  cancel(): void;
+}
+
+export interface ScanRuntimeAdapter {
+  start: (request: ResolvedScanRuntimeRequest, emit: ScanSnapshotEmitter) => ScanRuntimeRun;
+}
+
+export interface ScanRuntimeOptions {
+  adapter: ScanRuntimeAdapter;
+  initialSnapshot?: ScanLifecycleSnapshot;
+  defaultPath: string;
+  defaultExcludedPaths?: string[];
+  onSnapshot?: ScanSnapshotEmitter;
+}
+
+export interface ScanRuntime {
+  readonly snapshot: ScanLifecycleSnapshot;
+  canCancel(): boolean;
+  canRescan(): boolean;
+  start(request?: ScanRuntimeRequest): ResolvedScanRuntimeRequest;
+  cancel(): boolean;
+}
+
+export function createScanRuntime(options: ScanRuntimeOptions): ScanRuntime {
+  let snapshot = cloneSnapshot(options.initialSnapshot ?? createInitialScanLifecycleSnapshot());
+  let activeRun: ScanRuntimeRun | null = null;
+  let runVersion = 0;
+
+  const publish = (nextSnapshot: ScanLifecycleSnapshot, version = runVersion) => {
+    if (version !== runVersion) return;
+
+    snapshot = cloneSnapshot(nextSnapshot);
+    options.onSnapshot?.(cloneSnapshot(snapshot));
+    if (!isActiveScanState(snapshot.state)) {
+      activeRun = null;
+    }
+  };
+
+  const runtime: ScanRuntime = {
+    get snapshot() {
+      return cloneSnapshot(snapshot);
+    },
+    canCancel() {
+      return isActiveScanState(snapshot.state);
+    },
+    canRescan() {
+      return !isActiveScanState(snapshot.state);
+    },
+    start(request = {}) {
+      activeRun?.cancel();
+      runVersion += 1;
+
+      const version = runVersion;
+      const resolvedRequest = resolveScanRuntimeRequest(options, request);
+      publish(createStartingSnapshot(resolvedRequest.path), version);
+
+      let finishedDuringStart = false;
+      const emit = (nextSnapshot: ScanLifecycleSnapshot) => {
+        publish(nextSnapshot, version);
+        if (!isActiveScanState(nextSnapshot.state)) finishedDuringStart = true;
+      };
+
+      try {
+        const run = options.adapter.start(resolvedRequest, emit);
+        activeRun = finishedDuringStart ? null : run;
+      } catch (error) {
+        publish(createErrorSnapshot(error), version);
+      }
+
+      return resolvedRequest;
+    },
+    cancel() {
+      if (!isActiveScanState(snapshot.state)) return false;
+
+      activeRun?.cancel();
+      activeRun = null;
+      runVersion += 1;
+      snapshot = cancelScan(snapshot);
+      options.onSnapshot?.(cloneSnapshot(snapshot));
+      return true;
+    },
+  };
+
+  return runtime;
+}
+
+export function cloneSnapshot(snapshot: ScanLifecycleSnapshot): ScanLifecycleSnapshot {
+  return {
+    ...snapshot,
+    progress: { ...snapshot.progress },
+  };
+}
+
+export function createStartingSnapshot(path: string): ScanLifecycleSnapshot {
+  return {
+    state: "starting",
+    progress: { ...initialScanProgress, currentPath: path },
+    result: null,
+    error: null,
+  };
+}
+
+export function createErrorSnapshot(error: unknown): ScanLifecycleSnapshot {
+  const normalizedError = error instanceof Error ? error : new Error("Scanner failed");
+  return failScan(createInitialScanLifecycleSnapshot(), normalizedError);
+}
+
+function resolveScanRuntimeRequest(
+  options: ScanRuntimeOptions,
+  request: ScanRuntimeRequest,
+): ResolvedScanRuntimeRequest {
+  return {
+    path: request.path?.trim() || options.defaultPath,
+    excludedPaths: request.excludedPaths ?? options.defaultExcludedPaths ?? [],
+    deepScanGenerated: request.deepScanGenerated ?? false,
+  };
+}

--- a/packages/scanner/src/schema.ts
+++ b/packages/scanner/src/schema.ts
@@ -62,6 +62,8 @@ export const scanNodeSchema: z.ZodType<ScanNode> = z.lazy(() =>
     logicalSize: z.number().int().nonnegative(),
     allocatedSize: z.number().int().nonnegative().nullable(),
     childCount: z.number().int().nonnegative(),
+    omittedChildCount: z.number().int().nonnegative().default(0),
+    childrenTruncated: z.boolean().default(false),
     status: scanStatusSchema,
     classification: scanClassificationSchema.nullable().default(null),
     children: z.array(scanNodeSchema),
@@ -75,6 +77,8 @@ export interface ScanNode {
   logicalSize: number;
   allocatedSize: number | null;
   childCount: number;
+  omittedChildCount: number;
+  childrenTruncated: boolean;
   status: ScanStatus;
   classification: ScanClassification | null;
   children: ScanNode[];
@@ -114,6 +118,7 @@ export const scanProgressSchema = z.object({
   pathsScanned: z.number().int().nonnegative(),
   directoriesScanned: z.number().int().nonnegative(),
   filesScanned: z.number().int().nonnegative(),
+  logicalSizeScanned: z.number().int().nonnegative().default(0),
   currentPath: z.string().nullable(),
 });
 export type ScanProgress = z.infer<typeof scanProgressSchema>;
@@ -138,6 +143,7 @@ export const initialScanProgress = {
   pathsScanned: 0,
   directoriesScanned: 0,
   filesScanned: 0,
+  logicalSizeScanned: 0,
   currentPath: null,
 } satisfies ScanProgress;
 


### PR DESCRIPTION
This PR improves scanner performance and responsiveness by bounding serialized directory children, summarizing generated dependency/cache folders by default, adding exact deep-scan support, caching reusable package aggregates, and exposing progress bytes plus skip diagnostics through the scanner contract.

The previous scan path could spend too much time and memory traversing large generated trees and serializing enormous child lists, which made home-folder and dependency-heavy scans slow or hard to use; the root cause was that every directory was recursively materialized into the report without policy-aware summarization or bounded presentation output.

The fix splits native reporting into policy, JSON, summary, aggregate-cache, and scanner modules; adds CLI/UI exclude and deep-scan controls; shares scan lifecycle handling through a runtime abstraction; and packages the compiled scanner executable into the desktop app so packaged builds do not rely on a source checkout.

Validation: `bun --filter @zpace/scanner test`, `bun --filter web test --run`, `cd packages/scanner && bun run check-types`, `cd apps/desktop && bun run check-types`, `cd apps/web && bun run build`, `bun --filter desktop build:stable`, app-bundle inspection for `Resources/app/scanner/zpace-scanner`, and a manual executable-path scan with a missing source root.
