### PR TITLE
[codex] Polish scanner interface

### DIFF
--- a/apps/web/src/components/radial-usage-map.tsx
+++ b/apps/web/src/components/radial-usage-map.tsx
@@ -21,9 +21,11 @@ interface IndexedNode {
   breadcrumbs: ScanNode[];
 }
 
-const center = 160;
+const viewBoxSize = 360;
+const center = viewBoxSize / 2;
 const innerRadius = 54;
 const ringWidth = 42;
+const ringGap = 5;
 const gapRadians = 0.008;
 const palette = ["#34d399", "#60a5fa", "#f59e0b", "#f472b6", "#a78bfa", "#2dd4bf"];
 
@@ -69,15 +71,24 @@ export function RadialUsageMap(props: RadialUsageMapProps) {
           </For>
         </nav>
 
-        <div class="relative mx-auto mt-4 aspect-square max-w-80">
-          <svg viewBox="0 0 320 320" role="img" aria-label={`Disk usage map for ${currentNode().name}`}>
+        <div class="relative mx-auto mt-4 aspect-square w-full max-w-64 sm:max-w-80">
+          <svg
+            viewBox={`0 0 ${viewBoxSize} ${viewBoxSize}`}
+            role="img"
+            aria-label={`Disk usage map for ${currentNode().name}`}
+          >
             <circle cx={center} cy={center} r={innerRadius - 4} class="fill-neutral-950 stroke-neutral-800" />
             <For each={segments()}>
               {(segment, index) => (
                 <path
-                  d={arcPath(segment.startAngle, segment.endAngle, radiusForDepth(segment.depth), radiusForDepth(segment.depth + 1) - 5)}
+                  d={arcPath(
+                    segment.startAngle,
+                    segment.endAngle,
+                    radiusForDepth(segment.depth),
+                    radiusForDepth(segment.depth + 1) - ringGap,
+                  )}
                   fill={palette[index() % palette.length]}
-                  class="cursor-pointer opacity-90 outline-none transition hover:opacity-100 focus:opacity-100"
+                  class="cursor-pointer opacity-90 outline-none transition hover:opacity-100 focus:opacity-100 focus-visible:stroke-neutral-50 focus-visible:stroke-2"
                   tabIndex={0}
                   role="button"
                   aria-label={`${segment.node.name}, ${formatBytes(segment.node.logicalSize)}`}

--- a/apps/web/src/components/scan-list.tsx
+++ b/apps/web/src/components/scan-list.tsx
@@ -105,8 +105,8 @@ export function ScanList(props: ScanListProps) {
             </For>
           </nav>
 
-          <div class="flex flex-wrap items-center gap-2">
-            <label class="flex items-center gap-2 text-xs text-neutral-500">
+          <div class="grid gap-2 sm:flex sm:flex-wrap sm:items-center">
+            <label class="grid gap-1 text-xs text-neutral-500 sm:flex sm:items-center sm:gap-2">
               Category
               <select
                 class="h-8 rounded-md border border-neutral-700 bg-neutral-950 px-2 text-xs text-neutral-200"
@@ -120,7 +120,7 @@ export function ScanList(props: ScanListProps) {
               </select>
             </label>
 
-            <label class="flex items-center gap-2 text-xs text-neutral-500">
+            <label class="grid gap-1 text-xs text-neutral-500 sm:flex sm:items-center sm:gap-2">
               Sort
               <select
                 class="h-8 rounded-md border border-neutral-700 bg-neutral-950 px-2 text-xs text-neutral-200"
@@ -155,7 +155,7 @@ export function ScanList(props: ScanListProps) {
         </div>
       </div>
 
-      <div class="grid grid-cols-[minmax(0,1fr)_7rem_7rem_10rem_8rem_6rem] gap-4 border-b border-neutral-800 px-4 py-3 text-xs font-medium uppercase text-neutral-500">
+      <div class="hidden grid-cols-[minmax(0,1fr)_7rem_7rem_10rem_8rem_6rem] gap-4 border-b border-neutral-800 px-4 py-3 text-xs font-medium uppercase text-neutral-500 lg:grid">
         <span>Item</span>
         <span class="text-right">Logical</span>
         <span class="text-right">Allocated</span>
@@ -167,7 +167,7 @@ export function ScanList(props: ScanListProps) {
         <For each={rows()}>
           {(row) => (
             <li
-              class="grid grid-cols-[minmax(0,1fr)_7rem_7rem_10rem_8rem_6rem] gap-4 border-b border-neutral-800 px-4 py-3 last:border-b-0"
+              class="grid gap-3 border-b border-neutral-800 px-4 py-3 last:border-b-0 lg:grid-cols-[minmax(0,1fr)_7rem_7rem_10rem_8rem_6rem] lg:gap-4"
               data-scan-row={row.node.name}
             >
               <div class="flex min-w-0 items-center gap-3">
@@ -192,12 +192,16 @@ export function ScanList(props: ScanListProps) {
                   <p class="truncate text-xs text-neutral-500">{row.node.path}</p>
                 </div>
               </div>
-              <div class="self-center text-right text-sm tabular-nums text-neutral-300">
-                {row.sizeLabel}
-              </div>
-              <div class="self-center text-right text-sm tabular-nums text-neutral-300">
-                {row.allocatedSizeLabel}
-              </div>
+              <dl class="grid grid-cols-2 gap-3 text-sm lg:contents">
+                <div class="lg:self-center lg:text-right lg:tabular-nums lg:text-neutral-300">
+                  <dt class="text-[11px] uppercase text-neutral-500 lg:sr-only">Logical</dt>
+                  <dd class="mt-0.5 tabular-nums text-neutral-300">{row.sizeLabel}</dd>
+                </div>
+                <div class="lg:self-center lg:text-right lg:tabular-nums lg:text-neutral-300">
+                  <dt class="text-[11px] uppercase text-neutral-500 lg:sr-only">Allocated</dt>
+                  <dd class="mt-0.5 tabular-nums text-neutral-300">{row.allocatedSizeLabel}</dd>
+                </div>
+              </dl>
               <div class="min-w-0 self-center">
                 <Show
                   when={row.node.classification}
@@ -225,7 +229,7 @@ export function ScanList(props: ScanListProps) {
                   )}
                 </Show>
               </div>
-              <div class="self-center text-right">
+              <div class="self-center lg:text-right">
                 <span class="rounded-md border border-neutral-700 px-2 py-1 text-xs text-neutral-300">
                   {row.node.status}
                 </span>
@@ -244,7 +248,7 @@ export function ScanList(props: ScanListProps) {
                   </button>
                 </Show>
               </div>
-              <div class="self-center text-right">
+              <div class="self-center lg:text-right">
                 <QueueButton
                   node={row.node}
                   isQueued={props.queuedPaths?.has(row.node.path) ?? false}

--- a/apps/web/src/lib/scan-presentation.test.ts
+++ b/apps/web/src/lib/scan-presentation.test.ts
@@ -52,7 +52,7 @@ describe("scan presentation", () => {
     ).toEqual([
       { label: "paths", value: "4" },
       { label: "files", value: "1" },
-      { label: "size", value: "321 KB" },
+      { label: "logical", value: "321 KB" },
       { label: "warnings", value: "0" },
       { label: "state", value: "complete" },
     ]);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,7 +1,5 @@
 import { Outlet, createRootRouteWithContext } from "@tanstack/solid-router";
-import { TanStackRouterDevtools } from "@tanstack/solid-router-devtools";
 
-import Header from "@/components/header";
 export interface RouterContext {}
 
 export const Route = createRootRouteWithContext<RouterContext>()({
@@ -9,13 +7,5 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 });
 
 function RootComponent() {
-  return (
-    <>
-      <div class="grid grid-rows-[auto_1fr] h-svh">
-        <Header />
-        <Outlet />
-      </div>
-      <TanStackRouterDevtools />
-    </>
-  );
+  return <Outlet />;
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -123,19 +123,20 @@ function App() {
 
   return (
     <main class="min-h-screen bg-neutral-950 text-neutral-100">
-      <section class="border-b border-neutral-800 bg-neutral-900/60">
-        <div class="mx-auto flex max-w-5xl flex-col gap-4 px-5 py-6 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h1 class="text-2xl font-semibold tracking-normal">zpace scan tracer</h1>
+      <section class="border-b border-neutral-800 bg-neutral-900/70">
+        <div class="mx-auto flex max-w-6xl flex-col gap-5 px-4 py-6 sm:px-6 lg:flex-row lg:items-end lg:justify-between">
+          <div class="min-w-0">
+            <p class="text-xs font-medium uppercase text-emerald-300">Disk scanner</p>
+            <h1 class="mt-2 text-2xl font-semibold tracking-normal">zpace scan tracer</h1>
             <p class="mt-2 max-w-2xl text-sm text-neutral-400">
               Native Zig scanner output rendered through the TypeScript app layer.
             </p>
           </div>
-          <div class="flex flex-col gap-4 sm:items-end">
+          <div class="flex flex-col gap-4 lg:items-end">
             <div class="flex gap-2">
               <button
                 type="button"
-                class="inline-flex h-9 items-center gap-2 rounded-md border border-neutral-700 px-3 text-sm font-medium text-neutral-100 disabled:cursor-not-allowed disabled:opacity-40"
+                class="inline-flex h-9 items-center gap-2 rounded-md border border-emerald-500/60 px-3 text-sm font-medium text-emerald-100 hover:bg-emerald-500/10 disabled:cursor-not-allowed disabled:opacity-40"
                 disabled={!scan()?.canRescan()}
                 onClick={() => startScan()}
               >
@@ -144,7 +145,7 @@ function App() {
               </button>
               <button
                 type="button"
-                class="inline-flex h-9 items-center gap-2 rounded-md border border-red-500/60 px-3 text-sm font-medium text-red-100 disabled:cursor-not-allowed disabled:opacity-40"
+                class="inline-flex h-9 items-center gap-2 rounded-md border border-red-500/50 px-3 text-sm font-medium text-red-100 hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-40"
                 disabled={!scan()?.canCancel()}
                 onClick={() => scan()?.cancel()}
               >
@@ -152,7 +153,7 @@ function App() {
                 Cancel
               </button>
             </div>
-            <dl class="grid grid-cols-2 gap-3 text-right sm:grid-cols-5">
+            <dl class="grid grid-cols-2 gap-3 sm:grid-cols-5 lg:text-right">
               <For each={summary()}>
                 {(item) => (
                   <div>
@@ -165,7 +166,7 @@ function App() {
           </div>
         </div>
       </section>
-      <div class="mx-auto max-w-5xl px-5 py-6">
+      <div class="mx-auto max-w-6xl px-4 py-6 sm:px-6">
         <section class="mb-5 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
           <div class="flex flex-col gap-3 md:flex-row md:items-end">
             <label class="min-w-0 flex-1 text-sm text-neutral-400">
@@ -179,7 +180,7 @@ function App() {
             </label>
             <button
               type="button"
-              class="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-emerald-500/60 px-3 text-sm font-medium text-emerald-100 disabled:cursor-not-allowed disabled:opacity-40"
+              class="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-emerald-500/60 px-4 text-sm font-medium text-emerald-100 hover:bg-emerald-500/10 disabled:cursor-not-allowed disabled:opacity-40 md:min-w-28"
               disabled={!scan()?.canRescan()}
               onClick={() => startScan()}
             >

--- a/packages/scanner/native/src/report_json.zig
+++ b/packages/scanner/native/src/report_json.zig
@@ -159,18 +159,56 @@ fn writeDiagnostic(writer: anytype, diagnostic: report.Diagnostic) !void {
 
 pub fn writeJsonString(writer: anytype, value: []const u8) !void {
     try writer.writeByte('"');
-    for (value) |char| {
+    var index: usize = 0;
+    while (index < value.len) {
+        const char = value[index];
         switch (char) {
-            '"' => try writer.writeAll("\\\""),
-            '\\' => try writer.writeAll("\\\\"),
-            '\n' => try writer.writeAll("\\n"),
-            '\r' => try writer.writeAll("\\r"),
-            '\t' => try writer.writeAll("\\t"),
+            '"' => {
+                try writer.writeAll("\\\"");
+                index += 1;
+            },
+            '\\' => {
+                try writer.writeAll("\\\\");
+                index += 1;
+            },
+            '\n' => {
+                try writer.writeAll("\\n");
+                index += 1;
+            },
+            '\r' => {
+                try writer.writeAll("\\r");
+                index += 1;
+            },
+            '\t' => {
+                try writer.writeAll("\\t");
+                index += 1;
+            },
             else => {
                 if (char < 0x20) {
                     try writer.print("\\u{x:0>4}", .{char});
-                } else {
+                    index += 1;
+                } else if (char < 0x80) {
                     try writer.writeByte(char);
+                    index += 1;
+                } else {
+                    const sequence_len = std.unicode.utf8ByteSequenceLength(char) catch {
+                        try writer.writeAll("\\uFFFD");
+                        index += 1;
+                        continue;
+                    };
+                    if (index + sequence_len > value.len) {
+                        try writer.writeAll("\\uFFFD");
+                        index += 1;
+                        continue;
+                    }
+                    const sequence = value[index..][0..sequence_len];
+                    _ = std.unicode.utf8Decode(sequence) catch {
+                        try writer.writeAll("\\uFFFD");
+                        index += 1;
+                        continue;
+                    };
+                    try writer.writeAll(sequence);
+                    index += sequence_len;
                 }
             },
         }
@@ -193,4 +231,13 @@ test "escapes JSON strings" {
     try writeJsonString(&stream.writer, "a\"b\\c\n");
 
     try std.testing.expectEqualStrings("\"a\\\"b\\\\c\\n\"", stream.written());
+}
+
+test "keeps valid utf-8 and replaces invalid filesystem bytes" {
+    var stream = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer stream.deinit();
+
+    try writeJsonString(&stream.writer, "ok 😄 \xffbad");
+
+    try std.testing.expectEqualStrings("\"ok 😄 \\uFFFDbad\"", stream.written());
 }

--- a/packages/scanner/src/presentation.test.ts
+++ b/packages/scanner/src/presentation.test.ts
@@ -90,7 +90,7 @@ describe("scanner presentation", () => {
     ).toEqual([
       { label: "paths", value: "4" },
       { label: "files", value: "1" },
-      { label: "size", value: "321 KB" },
+      { label: "logical", value: "321 KB" },
       { label: "warnings", value: "1" },
       { label: "state", value: "complete" },
     ]);

--- a/packages/scanner/src/presentation.ts
+++ b/packages/scanner/src/presentation.ts
@@ -42,7 +42,7 @@ export function summarizeScanSnapshot(snapshot: ScanLifecycleSnapshot): ScanLabe
     { label: "paths", value: snapshot.progress.pathsScanned.toString() },
     { label: "files", value: snapshot.progress.filesScanned.toString() },
     {
-      label: "size",
+      label: "logical",
       value: formatBytes(snapshot.result?.root.logicalSize ?? snapshot.progress.logicalSizeScanned),
     },
     { label: "warnings", value: snapshot.result?.diagnostics.length.toString() ?? "0" },


### PR DESCRIPTION
This PR polishes the scanner interface so the page reads as a focused product surface, removes the placeholder router header/devtools chrome, improves the scan controls, and makes the scan list usable on narrow screens by switching from a squeezed table to stacked rows.
It also fixes the radial usage map clipping by expanding the SVG viewBox, sizing the chart more conservatively on mobile, and adding visible focus treatment for keyboard users.
The scanner presentation label for live snapshot size is renamed from `size` to `logical`, with web and scanner tests updated to match the contract.
Native JSON string serialization now preserves valid UTF-8 while replacing invalid filesystem bytes with `\uFFFD`, with coverage for that behavior.

Validation: `bun --filter web test`, `bun --filter @zpace/scanner test`, and `bun run build`.
